### PR TITLE
fix(auth): prevent app from rendering inside MSAL popup window

### DIFF
--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,6 +7,12 @@ import './index.css'
 
 // Initialize MSAL before rendering
 initializeMsal().then(() => {
+  // If this window is an MSAL popup/redirect, don't render the app.
+  // MSAL will handle communication back to the opener window and close this popup.
+  if (window.opener && window.opener !== window) {
+    return; // Let MSAL close the popup
+  }
+
   ReactDOM.createRoot(document.getElementById('root')).render(
     <React.StrictMode>
       <MsalProvider instance={msalInstance}>


### PR DESCRIPTION
After Microsoft login, the popup window was rendering the full app instead of closing. Now we detect the popup context (window.opener) and skip rendering, letting MSAL handle the popup lifecycle.