### PR TITLE
fix(infra): stable staging URLs - no redirect URI registration needed

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -48,7 +48,7 @@ jobs:
           done
 
           # Stop PostgreSQL server to save costs
-          SERVER_NAME="psql-staging"
+          SERVER_NAME="psql-teamskills-staging"
           STATE=$(az postgres flexible-server show \
             --name "$SERVER_NAME" --resource-group "$RG" \
             --query "state" -o tsv 2>/dev/null || echo "NotFound")

--- a/.github/workflows/pr-staging.yml
+++ b/.github/workflows/pr-staging.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Wake up Postgres if stopped
         run: |
-          SERVER_NAME="psql-staging"
+          SERVER_NAME="psql-teamskills-staging"
           RG="${{ env.STAGING_RESOURCE_GROUP }}"
           
           # Check if server exists and is stopped

--- a/infra/staging/main.bicep
+++ b/infra/staging/main.bicep
@@ -76,7 +76,7 @@ resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01'
 
 // Shared PostgreSQL Server (stopped between PRs to save costs)
 resource postgresServer 'Microsoft.DBforPostgreSQL/flexibleServers@2023-06-01-preview' = {
-  name: 'psql-staging'
+  name: 'psql-teamskills-staging'
   location: location
   tags: tags
   sku: {


### PR DESCRIPTION
## Stable Staging URLs

Replaces per-PR resource names with stable shared names so the staging frontend URL never changes. This eliminates the need for the CI/CD service principal to have Microsoft Graph API permissions for managing Entra ID redirect URIs.

### What changed

| Before (per-PR) | After (stable) |
|---|---|
| `cae-staging-pr{N}` | `cae-staging` |
| `ca-frontend-pr{N}` | `ca-frontend-staging` |
| `ca-backend-pr{N}` | `ca-backend-staging` |
| `psql-staging-pr{N}` | `psql-staging` |
| `log-staging-pr{N}` | `log-staging` |

### Key changes

- **Stable URLs**: Frontend URL stays the same across all PRs. Register redirect URI once, works forever.
- **No more Graph API calls**: Removed `Register Entra ID redirect URIs` step from pr-staging.yml
- **Cost-efficient cleanup**: PR close scales apps to 0 and stops Postgres instead of deleting resources
- **Stored password**: PostgreSQL password stored as `STAGING_POSTGRES_PASSWORD` GitHub environment secret (no more random generation per deploy)
- **Cleaned up**: Deleted old per-PR staging resources (pr22, pr23) and stale redirect URIs

### Trade-off

Only one staging environment active at a time (latest PR wins). For a small team this is ideal.
