### PR TITLE
fix(auth): address all Round Table findings for production reliability

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Ensure shell scripts always have LF line endings (critical for Docker containers)
+*.sh text eol=lf
+
+# Squad: union merge for append-only team state files
+.squad/decisions.md merge=union
+.squad/agents/*/history.md merge=union
+.squad/log/** merge=union
+.squad/orchestration-log/** merge=union

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -9,16 +9,16 @@ const jwt = require('jsonwebtoken');
 const jwksClient = require('jwks-rsa');
 const db = require('./db');
 
-// JWKS client for fetching Microsoft's signing keys
-// Use tenant-specific endpoint when configured, fall back to 'common' for demo mode
-const jwksUri = process.env.AZURE_AD_TENANT_ID
-  ? `https://login.microsoftonline.com/${process.env.AZURE_AD_TENANT_ID}/discovery/v2.0/keys`
-  : 'https://login.microsoftonline.com/common/discovery/v2.0/keys';
+// JWKS client for fetching Microsoft's signing keys.
+// Always use the 'common' endpoint — it serves keys for all tenants, which is
+// required for multi-tenant apps (AzureADMultipleOrgs) where tokens come from
+// any Entra ID tenant.
+const jwksUri = 'https://login.microsoftonline.com/common/discovery/v2.0/keys';
 
 const client = jwksClient({
   jwksUri,
   cache: true,
-  cacheMaxAge: 86400000, // 24 hours
+  cacheMaxAge: 14400000, // 4 hours — short enough to pick up key rotations
   rateLimit: true,
   jwksRequestsPerMinute: 10
 });
@@ -47,13 +47,10 @@ function verifyToken(token) {
       algorithms: ['RS256']
     };
 
-    // Validate issuer when tenant ID is configured (prevents cross-tenant token abuse)
-    if (process.env.AZURE_AD_TENANT_ID) {
-      options.issuer = [
-        `https://login.microsoftonline.com/${process.env.AZURE_AD_TENANT_ID}/v2.0`,
-        `https://sts.windows.net/${process.env.AZURE_AD_TENANT_ID}/`
-      ];
-    }
+    // Issuer validation is intentionally skipped for multi-tenant apps.
+    // Each tenant's tokens carry that tenant's issuer URL, so there is no single
+    // issuer to validate against. The audience check (api://{clientId}) is
+    // sufficient — only tokens explicitly requested for THIS app will pass.
 
     jwt.verify(token, getKey, options, (err, decoded) => {
       if (err) {
@@ -116,7 +113,9 @@ async function findOrCreateUser(claims) {
  * Check if Entra ID authentication is configured
  */
 function isAuthConfigured() {
-  return !!(process.env.AZURE_AD_CLIENT_ID && process.env.AZURE_AD_TENANT_ID);
+  // Only AZURE_AD_CLIENT_ID is required — tenant ID is used by the frontend
+  // for MSAL authority but is not needed for backend JWT validation.
+  return !!process.env.AZURE_AD_CLIENT_ID;
 }
 
 /**

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -251,16 +251,16 @@ describe('Auth Middleware', () => {
       delete process.env.AZURE_AD_TENANT_ID;
     });
 
-    it('should return false when both env vars are missing', () => {
+    it('should return false when CLIENT_ID is missing', () => {
       delete process.env.AZURE_AD_CLIENT_ID;
       delete process.env.AZURE_AD_TENANT_ID;
       expect(isAuthConfigured()).toBe(false);
     });
 
-    it('should return false when only CLIENT_ID is set', () => {
+    it('should return true when only CLIENT_ID is set (multi-tenant)', () => {
       process.env.AZURE_AD_CLIENT_ID = 'test-id';
       delete process.env.AZURE_AD_TENANT_ID;
-      expect(isAuthConfigured()).toBe(false);
+      expect(isAuthConfigured()).toBe(true);
     });
 
     it('should return true when both env vars are set', () => {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,27 +1,34 @@
 // API utility for making requests to the backend
+import { InteractionRequiredAuthError } from '@azure/msal-browser';
 import { msalInstance, loginRequest } from './authConfig';
 import { getConfig } from './config';
 
 const API_BASE_URL = getConfig('VITE_API_URL');
 
 /**
- * Get access token for API calls
- * Returns null if not authenticated or auth not configured
+ * Get access token for API calls.
+ * Falls back to interactive login if the refresh token is expired.
+ * Returns null only if no account is signed in.
  */
 async function getAccessToken() {
-  try {
-    const accounts = msalInstance.getAllAccounts();
-    if (accounts.length === 0) {
-      return null;
-    }
+  const accounts = msalInstance.getAllAccounts();
+  if (accounts.length === 0) {
+    return null;
+  }
 
+  try {
     const response = await msalInstance.acquireTokenSilent({
       ...loginRequest,
       account: accounts[0]
     });
-
     return response.accessToken;
   } catch (error) {
+    if (error instanceof InteractionRequiredAuthError) {
+      // Refresh token expired or consent required — redirect to login
+      await msalInstance.acquireTokenRedirect(loginRequest);
+      // acquireTokenRedirect navigates away; this line is never reached
+      return null;
+    }
     console.warn('[API] Could not get access token:', error.message);
     return null;
   }

--- a/infra/app/backend.bicep
+++ b/infra/app/backend.bicep
@@ -29,10 +29,6 @@ param azureAdClientId string = ''
 @description('Microsoft Entra ID Tenant ID (optional)')
 param azureAdTenantId string = ''
 
-@secure()
-@description('Microsoft Entra ID Client Secret for Easy Auth (optional)')
-param azureAdClientSecret string = ''
-
 resource containerAppsEnvironment 'Microsoft.App/managedEnvironments@2023-05-01' existing = {
   name: containerAppsEnvironmentName
 }
@@ -147,7 +143,9 @@ output principalId string = backend.identity.principalId
 // NOTE: Easy Auth explicitly disabled on backend — Express middleware handles JWT validation directly.
 // This is the standard pattern for SPA + API: MSAL sends Bearer tokens, Express validates via JWKS.
 // We must keep this resource to ensure Easy Auth stays disabled (removing it doesn't delete the config).
-resource backendAuth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = if (!empty(azureAdClientId) && !empty(azureAdTenantId)) {
+// Always deployed unconditionally — if env vars are empty and this resource
+// isn't deployed, any pre-existing Easy Auth config would persist.
+resource backendAuth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = {
   parent: backend
   name: 'current'
   properties: {

--- a/infra/app/frontend.bicep
+++ b/infra/app/frontend.bicep
@@ -93,7 +93,9 @@ output principalId string = frontend.identity.principalId
 // NOTE: Easy Auth explicitly disabled on frontend — MSAL.js handles authentication directly in the browser.
 // This is the standard pattern for SPAs: MSAL acquires tokens client-side, sends to backend via Bearer header.
 // We must keep this resource to ensure Easy Auth stays disabled (removing it doesn't delete the config).
-resource frontendAuth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = if (!empty(azureAdClientId) && !empty(azureAdTenantId)) {
+// Always deployed unconditionally — if env vars are empty and this resource
+// isn't deployed, any pre-existing Easy Auth config would persist.
+resource frontendAuth 'Microsoft.App/containerApps/authConfigs@2023-05-01' = {
   parent: frontend
   name: 'current'
   properties: {

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -28,10 +28,6 @@ param azureAdClientId string = ''
 @description('Microsoft Entra ID Tenant ID for authentication (optional)')
 param azureAdTenantId string = ''
 
-@secure()
-@description('Microsoft Entra ID Client Secret for Easy Auth (optional)')
-param azureAdClientSecret string = ''
-
 var abbrs = loadJsonContent('./abbreviations.json')
 var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
 var tags = { 'azd-env-name': environmentName }
@@ -111,7 +107,6 @@ module backend './app/backend.bicep' = {
     frontendUrl: 'https://${abbrs.appContainerApps}frontend-${resourceToken}.${containerApps.outputs.defaultDomain}'
     azureAdClientId: azureAdClientId
     azureAdTenantId: azureAdTenantId
-    azureAdClientSecret: azureAdClientSecret
   }
 }
 


### PR DESCRIPTION
## Summary

Addresses all 5 issues identified by the Round Table review (3-model AI consensus) for production auth reliability.

### Changes

**Frontend (api.js):**
- Add `InteractionRequiredAuthError` fallback to `acquireTokenRedirect` when `acquireTokenSilent` fails — prevents silent auth failures when refresh tokens expire

**Backend (auth.js):**
- Use `common` JWKS endpoint for multi-tenant support (`AzureADMultipleOrgs`)
- Remove single-tenant issuer validation — audience check (`api://{clientId}`) is sufficient for multi-tenant
- Reduce JWKS cache from 24h to 4h for key rotation safety
- `isAuthConfigured()` now only requires `AZURE_AD_CLIENT_ID` (tenant ID is frontend-only concern)

**Infrastructure (Bicep):**
- Make Easy Auth disable unconditional on both frontend and backend (remove `if` condition that left stale config when env vars empty)
- Remove dead `azureAdClientSecret` param from backend.bicep and main.bicep

**Tests:**
- Update `isAuthConfigured` tests for multi-tenant behavior (16/16 pass)
- All 67 backend tests pass

**Other:**
- Add `.gitattributes` with `*.sh text eol=lf` to prevent CRLF container crashes on Windows

### Context

These fixes come from a structured Round Table review where Claude Opus 4.6, GPT-5.3-Codex, and Gemini 3 Pro analyzed the auth implementation and reached consensus on 5 issues. See session research for full analysis.
