### PR TITLE
fix(cicd): target correct ACR (crgvojq4dgzbtk4)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -103,7 +103,7 @@ jobs:
       - name: Build and push backend image
         run: |
           az acr build \
-            --registry ${{ vars.ACR_NAME || 'crywmkgjccarkve' }} \
+            --registry ${{ vars.ACR_NAME || 'crgvojq4dgzbtk4' }} \
             --image backend:${{ github.sha }} \
             --image backend:latest \
             --file Dockerfile.backend \
@@ -117,7 +117,7 @@ jobs:
             --query 'properties.configuration.ingress.fqdn' -o tsv)"
 
           az acr build \
-            --registry ${{ vars.ACR_NAME || 'crywmkgjccarkve' }} \
+            --registry ${{ vars.ACR_NAME || 'crgvojq4dgzbtk4' }} \
             --image frontend:${{ github.sha }} \
             --image frontend:latest \
             --file Dockerfile.frontend \
@@ -131,7 +131,7 @@ jobs:
           az containerapp update \
             --name ${{ vars.BACKEND_APP || 'ca-backend-gvojq4dgzbtk4' }} \
             --resource-group ${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }} \
-            --image ${{ vars.ACR_NAME || 'crywmkgjccarkve' }}.azurecr.io/backend:${{ github.sha }} \
+            --image ${{ vars.ACR_NAME || 'crgvojq4dgzbtk4' }}.azurecr.io/backend:${{ github.sha }} \
             --set-env-vars \
               AZURE_AD_CLIENT_ID=${{ vars.AZURE_AD_CLIENT_ID }} \
               AZURE_AD_TENANT_ID=${{ vars.AZURE_AD_TENANT_ID }} \
@@ -142,7 +142,7 @@ jobs:
           az containerapp update \
             --name ${{ vars.FRONTEND_APP || 'ca-frontend-teamskills' }} \
             --resource-group ${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }} \
-            --image ${{ vars.ACR_NAME || 'crywmkgjccarkve' }}.azurecr.io/frontend:${{ github.sha }}
+            --image ${{ vars.ACR_NAME || 'crgvojq4dgzbtk4' }}.azurecr.io/frontend:${{ github.sha }}
 
       - name: Smoke test - Validate auth configuration
         run: |
@@ -212,6 +212,6 @@ jobs:
           echo "| Variable | Default |" >> $GITHUB_STEP_SUMMARY
           echo "|----------|---------|" >> $GITHUB_STEP_SUMMARY
           echo "| \`RESOURCE_GROUP\` | \`rg-teamskills-prod\` |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`ACR_NAME\` | \`crywmkgjccarkve\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`ACR_NAME\` | \`crgvojq4dgzbtk4\` |" >> $GITHUB_STEP_SUMMARY
           echo "| \`BACKEND_APP\` | \`ca-backend-gvojq4dgzbtk4\` |" >> $GITHUB_STEP_SUMMARY
           echo "| \`FRONTEND_APP\` | \`ca-frontend-teamskills\` |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Problem

PR #30 deploy failed with UNAUTHORIZED because CI/CD builds images to crywmkgjccarkve (azd-created ACR in rg-prod) but container apps pull from crgvojq4dgzbtk4 (original ACR in rg-teamskills-prod) using admin password auth.

## Fix

Changed the default ACR_NAME fallback from crywmkgjccarkve to crgvojq4dgzbtk4 in all 5 occurrences in ci-cd.yml.

## Why This Will Work

- SP has Contributor on rg-teamskills-prod (where crgvojq4dgzbtk4 lives)
- Container apps already have admin password secrets for crgvojq4dgzbtk4.azurecr.io
- No managed identity or AcrPull role change needed

## Testing

- 74 backend tests pass
- 24 frontend tests pass
- Lint clean