### PR TITLE
fix: deduplicate CSV import by matching users on name

### DIFF
--- a/backend/routes/admin.js
+++ b/backend/routes/admin.js
@@ -611,6 +611,31 @@ router.delete('/user-skills', requireAuth, requireAdmin, async (req, res) => {
   }
 });
 
+// Admin: reset all users (wipe duplicates, start fresh)
+router.post('/reset-users', async (req, res) => {
+  const { secret } = req.body;
+
+  const initSecret = process.env.INIT_SECRET;
+  if (!initSecret || secret !== initSecret) {
+    return res.status(401).json({ error: 'Unauthorized - INIT_SECRET required' });
+  }
+
+  try {
+    // Delete in dependency order: history → skills → users
+    await db.query('DELETE FROM user_skills_history');
+    await db.query('DELETE FROM user_skills');
+    await db.query('DELETE FROM users');
+
+    res.json({
+      message: 'All users, user_skills, and user_skills_history deleted. Re-initialize with /api/admin/init or sync.',
+      status: 'success'
+    });
+  } catch (error) {
+    console.error('Reset users error:', error);
+    res.status(500).json({ error: 'Failed to reset users' });
+  }
+});
+
 // Admin: sync skills from CSV or SharePoint
 // POST /api/admin/sync-skills
 // Body: { source: 'csv' | 'pivot-csv' | 'sharepoint', secret: string, csvContent?: string, filePath?: string }

--- a/backend/services/sharepoint.js
+++ b/backend/services/sharepoint.js
@@ -290,19 +290,19 @@ async function syncPivotToDatabase(pivotData) {
 
   // Phase 2: Upsert users and their skills
   for (const row of rows) {
-    // Generate a placeholder email from the display name
-    const emailSlug = row.name.toLowerCase().replace(/[^a-z0-9]+/g, '.').replace(/^\.+|\.+$/g, '');
-    const email = `${emailSlug}@placeholder.local`;
-
-    // Upsert user by email
-    let userResult = await db.query('SELECT id FROM users WHERE email = $1', [email]);
+    // Match existing user by display name (case-insensitive) to avoid duplicates
+    let userResult = await db.query('SELECT id FROM users WHERE LOWER(name) = LOWER($1)', [row.name]);
     if (userResult.rows.length > 0) {
+      // Update team but preserve existing email and entra_oid
       await db.query(
-        'UPDATE users SET name = $1, team = $2 WHERE email = $3',
-        [row.name, row.team, email]
+        'UPDATE users SET team = $1 WHERE id = $2',
+        [row.team, userResult.rows[0].id]
       );
       stats.users.updated++;
     } else {
+      // No existing user — create with placeholder email
+      const emailSlug = row.name.toLowerCase().replace(/[^a-z0-9]+/g, '.').replace(/^\.+|\.+$/g, '');
+      const email = `${emailSlug}@placeholder.local`;
       userResult = await db.query(
         'INSERT INTO users (name, email, team) VALUES ($1, $2, $3) RETURNING id',
         [row.name, email, row.team]


### PR DESCRIPTION
## Fix: Duplicate User Bug in CSV Import

### Problem
The pivot CSV importer (`syncPivotToDatabase`) created users with `@placeholder.local` emails, causing duplicates when users already existed with real emails (from Entra ID auth or prior seed data). Production showed Brandon Babcock x2, Eric Hansen x2.

### Changes
- **`backend/services/sharepoint.js`** — Match users by display name (case-insensitive) instead of placeholder email. On match: update team field, preserve email/entra_oid. On no match: create with placeholder email (existing behavior for new users).
- **`backend/routes/admin.js`** — Added `POST /api/admin/reset-users` endpoint (behind INIT_SECRET) to wipe all users/skills for clean re-import.

### Testing
- All 74 unit tests pass
- ESLint clean
