### PR TITLE
fix: link auth users to CSV-imported users by display name

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -98,6 +98,21 @@ async function findOrCreateUser(claims) {
     }
   }
 
+  // Try to find by display name (links CSV-imported users who have placeholder emails)
+  result = await db.query(
+    'SELECT * FROM users WHERE LOWER(name) = LOWER($1)',
+    [name]
+  );
+
+  if (result.rows.length > 0) {
+    const user = result.rows[0];
+    await db.query(
+      'UPDATE users SET entra_oid = $1, email = $2, updated_at = CURRENT_TIMESTAMP WHERE id = $3',
+      [oid, email, user.id]
+    );
+    return { ...user, entra_oid: oid, email };
+  }
+
   // Create new user
   result = await db.query(
     `INSERT INTO users (name, email, entra_oid, role, team) 

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -67,6 +67,34 @@ describe('Auth Middleware', () => {
       expect(result.entra_oid).toBe('test-oid-12345');
     });
 
+    it('should link CSV-imported user by name when oid and email miss', async () => {
+      const csvUser = {
+        id: 5,
+        name: 'Test User',
+        email: 'test.user@placeholder.local',
+        entra_oid: null
+      };
+
+      // First query (by oid) returns nothing
+      db.query.mockResolvedValueOnce({ rows: [] });
+      // Second query (by email) returns nothing (placeholder email doesn't match)
+      db.query.mockResolvedValueOnce({ rows: [] });
+      // Third query (by name) returns CSV user
+      db.query.mockResolvedValueOnce({ rows: [csvUser] });
+      // Fourth query (update oid + email)
+      db.query.mockResolvedValueOnce({ rows: [] });
+
+      const result = await findOrCreateUser(mockClaims);
+
+      expect(db.query).toHaveBeenCalledTimes(4);
+      expect(db.query).toHaveBeenNthCalledWith(3,
+        'SELECT * FROM users WHERE LOWER(name) = LOWER($1)',
+        ['Test User']
+      );
+      expect(result.entra_oid).toBe('test-oid-12345');
+      expect(result.email).toBe('test@example.com');
+    });
+
     it('should create new user if not found', async () => {
       const newUser = {
         id: 3,
@@ -81,12 +109,14 @@ describe('Auth Middleware', () => {
       db.query.mockResolvedValueOnce({ rows: [] });
       // Second query (by email) returns nothing
       db.query.mockResolvedValueOnce({ rows: [] });
-      // Third query (insert) returns new user
+      // Third query (by name) returns nothing
+      db.query.mockResolvedValueOnce({ rows: [] });
+      // Fourth query (insert) returns new user
       db.query.mockResolvedValueOnce({ rows: [newUser] });
 
       const result = await findOrCreateUser(mockClaims);
 
-      expect(db.query).toHaveBeenCalledTimes(3);
+      expect(db.query).toHaveBeenCalledTimes(4);
       expect(result).toEqual(newUser);
     });
 
@@ -99,12 +129,13 @@ describe('Auth Middleware', () => {
 
       db.query.mockResolvedValueOnce({ rows: [] });
       db.query.mockResolvedValueOnce({ rows: [] });
+      db.query.mockResolvedValueOnce({ rows: [] });
       db.query.mockResolvedValueOnce({ rows: [{ id: 4, email: 'user@company.com' }] });
 
       await findOrCreateUser(claims);
 
       // Verify INSERT used preferred_username as email
-      expect(db.query).toHaveBeenNthCalledWith(3,
+      expect(db.query).toHaveBeenNthCalledWith(4,
         expect.stringContaining('INSERT INTO users'),
         ['Company User', 'user@company.com', 'another-oid', 'Team Member', null]
       );


### PR DESCRIPTION
When a user logs in via Entra ID, findOrCreateUser now tries matching by display name (case-insensitive) after OID and email lookups fail. This prevents duplicate users when CSV imports create users with placeholder emails.

**Root cause:** CSV importer creates users with placeholder emails. When those users log in via Entra ID, their real email doesnt match, so a duplicate is created.

**Fix:** Added name-based lookup as third fallback in findOrCreateUser(). On match, updates the users entra_oid and email to link them.

**Tests:** New test for name-matching case. All 75 tests pass.