### PR TITLE
fix(frontend): hide chat panel when agent service not configured

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,7 +8,7 @@ const TrendsChart = lazy(() => import('./components/TrendsChart'));
 const GapAnalysis = lazy(() => import('./components/GapAnalysis'));
 import UserProfile from './components/UserProfile';
 import ErrorBoundary from './components/ErrorBoundary';
-import ChatPanel from './components/ChatPanel';
+import ChatPanel, { isAgentConfigured } from './components/ChatPanel';
 import DatabaseWakeOverlay from './components/DatabaseWakeOverlay';
 import useDatabaseWake from './hooks/useDatabaseWake';
 import useAuth from './hooks/useAuth';
@@ -350,7 +350,7 @@ function App() {
         </div>
       )}
 
-      <main className={`app-main ${(view === 'graph' || view === 'radar' || view === 'coverage' || view === 'trends' || view === 'gaps') ? 'graph-view' : ''} ${chatOpen && view !== 'profile' ? 'chat-open' : ''}`}>
+      <main className={`app-main ${(view === 'graph' || view === 'radar' || view === 'coverage' || view === 'trends' || view === 'gaps') ? 'graph-view' : ''} ${chatOpen && view !== 'profile' && isAgentConfigured() ? 'chat-open' : ''}`}>
         <ErrorBoundary>
           {view === 'matrix' && <SkillMatrix onUserSelect={handleUserSelect} isAdmin={isAdmin} isAuthenticated={!!currentUser} />}
           <Suspense fallback={<div style={{ color: '#888', textAlign: 'center', padding: '3rem' }}>Loading visualization...</div>}>
@@ -386,8 +386,8 @@ function App() {
         }}
       />
       
-      {/* Chat Panel - shown on matrix and graph views */}
-      {view !== 'profile' && (
+      {/* Chat Panel - shown when agent service is configured */}
+      {view !== 'profile' && isAgentConfigured() && (
         <ChatPanel 
           isOpen={chatOpen} 
           onToggle={() => setChatOpen(!chatOpen)} 

--- a/frontend/src/components/ChatPanel.jsx
+++ b/frontend/src/components/ChatPanel.jsx
@@ -1,8 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
 import ReactMarkdown from 'react-markdown';
+import { getConfig } from '../config';
 import './ChatPanel.css';
 
-const AGENT_URL = import.meta.env.VITE_AGENT_URL || 'http://localhost:8000';
+const AGENT_URL = getConfig('VITE_AGENT_URL');
+
+/** Returns true when the agent service URL is configured. */
+export function isAgentConfigured() {
+  return Boolean(getConfig('VITE_AGENT_URL'));
+}
 
 function ChatPanel({ isOpen, onToggle }) {
   const [messages, setMessages] = useState([]);


### PR DESCRIPTION
## Problem
The Skills Assistant chat button was visible in production, but the agent service (Python/FastAPI in \gent/\) was never deployed. \VITE_AGENT_URL\ was empty in production config.js, causing the frontend to fall back to \http://localhost:8000\ -- which fails in the browser with 'Failed to fetch'.

## Fix
- **ChatPanel.jsx**: Use \getConfig('VITE_AGENT_URL')\ instead of \import.meta.env.VITE_AGENT_URL\ (consistent with rest of app). Export \isAgentConfigured()\ helper.
- **App.jsx**: Only render ChatPanel when agent URL is configured. Also gate the \chat-open\ CSS class on agent availability.

## Testing
- PASS: Lint (0 errors)
- PASS: Backend unit tests (84/84)
- PASS: Frontend unit tests (24/24)
- PASS: Playwright E2E (13/13 on msedge)

## Result
When \VITE_AGENT_URL\ is empty (current prod state), the chat button is hidden. When agent is eventually deployed and URL configured, the button will automatically appear.