### PR TITLE
fix(ci): make INIT_SECRET optional in deploy pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -128,17 +128,22 @@ jobs:
 
       - name: Deploy backend
         run: |
-          az containerapp update \
-            --name ${{ vars.BACKEND_APP || 'ca-backend-gvojq4dgzbtk4' }} \
+          DEPLOY_ARGS="--name ${{ vars.BACKEND_APP || 'ca-backend-gvojq4dgzbtk4' }} \
             --resource-group ${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }} \
             --image ${{ vars.ACR_NAME || 'crgvojq4dgzbtk4' }}.azurecr.io/backend:${{ github.sha }} \
             --set-env-vars \
               AZURE_AD_CLIENT_ID=${{ vars.AZURE_AD_CLIENT_ID }} \
               AZURE_AD_TENANT_ID=${{ vars.AZURE_AD_TENANT_ID }} \
-              NODE_ENV=production \
-              INIT_SECRET=secretref:init-secret \
-            --set-secrets \
-              init-secret="${{ secrets.INIT_SECRET }}"
+              NODE_ENV=production"
+
+          # Only set INIT_SECRET if the GitHub secret is configured
+          if [ -n "$INIT_SECRET" ]; then
+            DEPLOY_ARGS="$DEPLOY_ARGS INIT_SECRET=secretref:init-secret --set-secrets init-secret=$INIT_SECRET"
+          fi
+
+          az containerapp update $DEPLOY_ARGS
+        env:
+          INIT_SECRET: ${{ secrets.INIT_SECRET }}
 
       - name: Deploy frontend
         run: |


### PR DESCRIPTION
## Problem
The CI/CD deploy step fails when INIT_SECRET is not set as a GitHub environment secret. The Azure CLI rejects an empty --set-secrets argument.

This caused the deploy to fail after PR #37 merge and will continue blocking all deploys.

## Fix
Make INIT_SECRET conditional -- only pass the --set-secrets and INIT_SECRET env var when the GitHub secret is non-empty.

## Impact
- Deploys work even without INIT_SECRET configured
- When INIT_SECRET is eventually added to GitHub secrets, it will automatically be included
