### PR TITLE
fix(ci): fail deploy on health check timeout + update troubleshooting docs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -191,24 +191,35 @@ jobs:
           AGENT_URL="https://$(az containerapp show -n "$AGENT_APP" -g "$RG" --query 'properties.configuration.ingress.fqdn' -o tsv)"
 
           echo "Waiting for backend to be ready..."
+          BACKEND_READY=false
           for i in $(seq 1 30); do
             if curl -sf "${BACKEND_URL}/health" | grep -q '"ok"'; then
               echo "✅ Backend is ready!"
+              BACKEND_READY=true
               break
             fi
             echo "Attempt $i/30: Backend not ready yet, waiting 10s..."
             sleep 10
           done
+          if [ "$BACKEND_READY" != "true" ]; then
+            echo "❌ Backend failed to become ready after 30 attempts (5 minutes)"
+            exit 1
+          fi
 
           echo "Waiting for agent to be ready..."
+          AGENT_READY=false
           for i in $(seq 1 15); do
             if curl -sf "${AGENT_URL}/health" | grep -q '"healthy"'; then
               echo "✅ Agent is ready!"
+              AGENT_READY=true
               break
             fi
             echo "Attempt $i/15: Agent not ready yet, waiting 10s..."
             sleep 10
           done
+          if [ "$AGENT_READY" != "true" ]; then
+            echo "⚠️ Agent failed to become ready (non-blocking)"
+          fi
 
       - name: Smoke test - Validate auth configuration
         run: |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -621,38 +621,59 @@ Production backend is configured with `minReplicas: 1` to prevent cold starts. S
 
 **Symptom:** CI/CD smoke test fails with `{"status":"unreachable"}`. Wait loop exhausts all 30 attempts (5 minutes).
 
-**Recent Occurrence:** CI/CD run 22681175346 (commit `90c54c9`) — backend never became healthy after merge of SharePoint OBO PR (`628ed55`).
+**Recent Occurrence:** CI/CD runs 22681175346 and 22686579591 — backend never became healthy after merge of SharePoint OBO PR (`628ed55`) and Node 22 fix (PR #44).
 
-**Investigation:**
-1. Images built successfully (npm install ran during `az acr build`)
-2. `az containerapp update` succeeded
-3. Wait loop tried 30 times, all failed
-4. Agent became healthy immediately (proving network/DNS is fine)
+**Root Cause (Resolved March 2026):**
+Two issues combined to cause the failure:
 
-**Likely Causes:**
+1. **Node version mismatch** — `@azure/msal-node@5.0.6` requires `node >= 20`, but `Dockerfile.backend` used `node:18-alpine`. CI tests passed because GitHub Actions used Node 22 (`actions/setup-node`), masking the Docker image incompatibility. **Fix:** PR #44 upgraded to `node:22-alpine`.
 
-#### 1. Container Crash Loop
+2. **PostgreSQL server stopped** — The Azure Flexible Server was in "Stopped" state, causing every health check to return "Connection terminated due to connection timeout." The Node.js server started fine but the `/health` endpoint queries the database and returned 503. **Fix:** `az postgres flexible-server start --name psql-gvojq4dgzbtk4 --resource-group rg-teamskills-prod`.
 
-New dependencies (e.g., `@azure/msal-node` from SharePoint PR) might cause:
-- Missing native modules
-- Import errors at module load time
-- Version incompatibilities
+**Investigation Steps (in order of likelihood):**
+
+#### 1. Database Stopped/Unreachable (Most Common)
+
+PostgreSQL Flexible Server may be stopped, paused, or unreachable.
+
+**Check database state:**
+```bash
+az postgres flexible-server show \
+  --name psql-gvojq4dgzbtk4 \
+  --resource-group rg-teamskills-prod \
+  --query "state" -o tsv
+```
+
+**Fix if stopped:**
+```bash
+az postgres flexible-server start \
+  --name psql-gvojq4dgzbtk4 \
+  --resource-group rg-teamskills-prod
+```
+
+> **Note:** The keep-alive cron job (every 10 min) pings the backend health endpoint, but if the database is stopped, the keep-alive itself fails silently. Check keep-alive workflow runs for recent failures as an early warning.
+
+#### 2. Container Crash Loop
+
+New dependencies might cause crashes. Check container logs:
 
 **Check logs:**
 ```bash
 az containerapp logs show \
   --name ca-backend-gvojq4dgzbtk4 \
   --resource-group rg-teamskills-prod \
-  --type system \
-  --follow
+  --type console \
+  --tail 50 --follow false
 ```
 
 Look for:
 - `Error: Cannot find module ...`
-- Segmentation faults
+- `engines.node` version mismatches (e.g., `@azure/msal-node` requires `node >= 20`)
 - Uncaught exceptions during startup
 
-#### 2. Missing Environment Variables
+**Pro tip:** If the server logs `running on port 3001` but health checks fail, the issue is database connectivity, not a crash.
+
+#### 3. Missing Environment Variables
 
 New code paths may require env vars that weren't set during deploy.
 
@@ -667,27 +688,7 @@ if (!clientId || !clientSecret || !tenantId) {
 
 **Fix:** Ensure lazy initialization — don't instantiate clients until they're actually used.
 
-#### 3. Database Connection Timeout
-
-PostgreSQL may be stopped/paused, and health check times out before it wakes.
-
-**Check:**
-```bash
-az postgres flexible-server show \
-  --name <server-name> \
-  --resource-group rg-teamskills-prod \
-  --query "state" -o tsv
-```
-
-**Fix:** Start the server manually or wait for auto-wake.
-
 #### 4. New Route Initialization Error
-
-SharePoint routes added in PR `628ed55`:
-```javascript
-const sharepointRouter = require('./routes/sharepoint');
-app.use('/api/sharepoint', sharepointRouter);
-```
 
 If `require('./routes/sharepoint')` fails (e.g., import error), server crashes before health endpoint is registered.
 
@@ -698,21 +699,29 @@ Error loading route: ...
 
 **Resolution Steps:**
 
-1. **Check container logs immediately:**
+1. **Check database state first** (most common cause):
+   ```bash
+   az postgres flexible-server show \
+     --name psql-gvojq4dgzbtk4 \
+     --resource-group rg-teamskills-prod \
+     --query "state" -o tsv
+   ```
+
+2. **Check container logs:**
    ```bash
    az containerapp logs show \
      --name ca-backend-gvojq4dgzbtk4 \
      --resource-group rg-teamskills-prod \
      --type console \
-     --follow
+     --tail 50 --follow false
    ```
 
-2. **Check system logs for restarts:**
+3. **Check revision health state:**
    ```bash
-   az containerapp logs show \
+   az containerapp revision list \
      --name ca-backend-gvojq4dgzbtk4 \
      --resource-group rg-teamskills-prod \
-     --type system
+     --query "[].{name:name, state:properties.runningState, health:properties.healthState}" -o table
    ```
 
 3. **Inspect current environment variables:**


### PR DESCRIPTION
## Summary

Fixes two issues discovered during the March 2026 prod outage investigation:

### 1. CI/CD Health Check Bug (ci-cd.yml)
The \Wait for new revisions to provision\ step had a bash \or\ loop that checked backend health 30 times (5 minutes), but **never exited with a non-zero code if all attempts failed**. This made the step appear successful even when the backend was completely down, allowing the workflow to silently pass.

**Fix:** Track readiness with a boolean flag and \xit 1\ after loop exhaustion. Agent health check remains non-blocking (warning only).

### 2. Deployment Troubleshooting Docs (docs/deployment.md)
Updated the troubleshooting section with the actual root cause chain discovered during the outage:

1. **Node version mismatch** (fixed in PR #44) — \@azure/msal-node@5.0.6\ requires \
ode >= 20\, Dockerfile used \
ode:18-alpine\
2. **PostgreSQL server stopped** — Azure Flexible Server was in \Stopped\ state, causing every health check to return \Connection terminated due to connection timeout\

Reordered investigation steps to check DB state first (most common cause) and added the \z postgres flexible-server show\ and \z containerapp revision list\ commands to the resolution checklist.

## Root Cause Resolution

The prod outage had two independent causes:
- **PR #44** fixed the Node version (necessary but not sufficient)
- **Manual intervention** started the stopped PostgreSQL server (\z postgres flexible-server start\)
- **CI/CD re-run** then passed all checks ✅ (run 22686579591)

## Testing
- Lint ✅ (0 errors)
- Backend tests ✅ (96 passed)
- Playwright E2E ✅ (13 passed, msedge)