### PR TITLE
fix(agent): Use correct streaming API for agent-framework SDK

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -146,10 +146,15 @@ class SkillsAgent:
                     yield {"type": "content", "content": result.text}
                 elif result.value:
                     yield {"type": "content", "content": str(result.value)}
+                else:
+                    yield {"type": "content", "content": "No response generated."}
                 yield {"type": "done"}
             except Exception as fallback_err:
                 logger.error(f"Agent fallback also failed: {fallback_err}")
-                yield {"type": "error", "content": str(e)}
+                yield {
+                    "type": "error",
+                    "content": "An unexpected error occurred while processing your request. Please try again later.",
+                }
     
     async def cleanup(self) -> None:
         """Clean up agent resources."""


### PR DESCRIPTION
## Summary

Fix the Skills Assistant chat panel which was completely unresponsive due to an incorrect streaming API call against the `agent-framework` SDK.

## Root Cause

`RawAgent.run(message, stream=True)` returns an **async iterable directly**, but the code was trying to iterate over `stream.updates` (a list), causing:
```
'async for' requires an object with __aiter__ method, got list
```

The endpoint returned HTTP 200 but immediately errored, so the frontend received no SSE events.

## Changes

- **`agent/agent.py`** — Iterate `agent.run(message, stream=True)` directly instead of `.updates`
- Added fallback to non-streaming `run()` if streaming fails, so chat degrades gracefully instead of silently dying

## Testing

- Deployed to prod and verified streaming works end-to-end
- Tested with "Who knows Kubernetes?" — returns correct results with real-time token streaming
