### PR TITLE
fix: always run Bicep for wake function infrastructure (idempotent)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -153,25 +153,19 @@ jobs:
         run: |
           RG="${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }}"
           FUNC_NAME="${{ vars.WAKE_FUNCTION_APP || 'func-wake-gvojq4dgzbtk4' }}"
+          PG_NAME="${{ vars.PG_SERVER_NAME || 'psql-gvojq4dgzbtk4' }}"
+          PG_ID=$(az postgres flexible-server show --name "$PG_NAME" --resource-group "$RG" --query id -o tsv)
 
-          # Check if function app already exists
-          if az functionapp show --name "$FUNC_NAME" --resource-group "$RG" &>/dev/null; then
-            echo "✅ Wake function app already exists, skipping provisioning"
-          else
-            echo "Provisioning wake function infrastructure..."
-            PG_NAME="${{ vars.PG_SERVER_NAME || 'psql-gvojq4dgzbtk4' }}"
-            PG_ID=$(az postgres flexible-server show --name "$PG_NAME" --resource-group "$RG" --query id -o tsv)
-
-            az deployment group create \
-              --resource-group "$RG" \
-              --template-file infra/app/wake-function.bicep \
-              --parameters \
-                name="$FUNC_NAME" \
-                postgresServerResourceId="$PG_ID" \
-                postgresServerName="$PG_NAME" \
-                resourceToken="${{ vars.RESOURCE_TOKEN || 'gvojq4dgzbtk4' }}"
-            echo "✅ Wake function infrastructure provisioned"
-          fi
+          echo "Deploying wake function infrastructure (idempotent)..."
+          az deployment group create \
+            --resource-group "$RG" \
+            --template-file infra/app/wake-function.bicep \
+            --parameters \
+              name="$FUNC_NAME" \
+              postgresServerResourceId="$PG_ID" \
+              postgresServerName="$PG_NAME" \
+              resourceToken="${{ vars.RESOURCE_TOKEN || 'gvojq4dgzbtk4' }}"
+          echo "✅ Wake function infrastructure up to date"
 
       - name: Deploy wake function code
         run: |


### PR DESCRIPTION
## Problem

CI/CD #201 failed to deploy the wake function code because the "Provision wake function infrastructure" step **skipped** the Bicep deployment when the Function App already existed:

```yaml
if az functionapp show --name "$FUNC_NAME" ... &>/dev/null; then
    echo "✅ Wake function app already exists, skipping provisioning"
```

This means PR #73's `allowSharedKeyAccess: true` fix never got applied to the storage account, so the code zip deploy continued to fail with 403 Forbidden.

## Fix

Remove the conditional check and always run `az deployment group create`. Bicep deployments are **idempotent** — running them when resources already exist just ensures they match the template. This is the correct pattern for CI/CD infrastructure management.

## What this unblocks

Once merged, the CI/CD will:
1. Re-deploy the Bicep → storage account gets `allowSharedKeyAccess: true`
2. Zip deploy succeeds → wake function code is deployed
3. Container apps get updated to latest images
4. Frontend gets `VITE_WAKE_FUNCTION_URL` set

---
*Created by Azure SRE Agent*