### PR TITLE
fix: make wake function deploy non-blocking for container apps

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,7 +149,12 @@ jobs:
         with:
           node-version: '22'
 
+      # Wake function steps are non-blocking: an Azure Policy enforces
+      # allowSharedKeyAccess=false on the storage account, which blocks
+      # SCM/Kudu zip deployment. We don't want this to prevent container
+      # app updates. Track fix in a separate issue.
       - name: Provision wake function infrastructure
+        continue-on-error: true
         run: |
           RG="${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }}"
           FUNC_NAME="${{ vars.WAKE_FUNCTION_APP || 'func-wake-gvojq4dgzbtk4' }}"
@@ -168,6 +173,7 @@ jobs:
           echo "✅ Wake function infrastructure up to date"
 
       - name: Deploy wake function code
+        continue-on-error: true
         run: |
           cd wake-function && npm ci --production && rm -f local.settings.json && cd ..
           (cd wake-function && zip -r ../wake-function.zip .)


### PR DESCRIPTION
## Problem

An Azure Policy enforces `allowSharedKeyAccess=false` on the wake function's storage account, which blocks the SCM/Kudu zip deployment. The Bicep successfully sets it to `true`, but the policy reverts it immediately. This causes the "Deploy wake function code" step to fail with 403, which kills the entire deploy job — meaning **container app updates (backend, frontend, agent) never execute**.

## Fix

Add `continue-on-error: true` to both wake function steps:
- "Provision wake function infrastructure"
- "Deploy wake function code"

This ensures the container app deployments (backend, agent, frontend with `VITE_WAKE_FUNCTION_URL`) always proceed regardless of wake function deployment status. The wake function will show a warning in the CI/CD output but won't block the pipeline.

## What changes

- Wake function provision/deploy failures become non-blocking warnings
- Container apps will finally get updated to latest images
- Frontend will get `VITE_WAKE_FUNCTION_URL` set
- The wake function code deployment policy issue will need a separate fix (either exempt the storage account from the policy, or switch to a deployment method that doesn't need SCM)

---
*Created by Azure SRE Agent*