### PR TITLE
fix(ci): split secret set from container update, harden deploy pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -218,35 +218,6 @@ jobs:
               VITE_AZURE_AD_TENANT_ID=${{ vars.AZURE_AD_TENANT_ID }} \
               VITE_AGENT_URL=$AGENT_URL
 
-      - name: Verify deployed image SHAs
-        run: |
-          RG="${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }}"
-          EXPECTED_SHA="${{ github.sha }}"
-          ALL_OK=true
-
-          for APP_PAIR in \
-            "backend:${{ vars.BACKEND_APP || 'ca-backend-gvojq4dgzbtk4' }}" \
-            "agent:${{ vars.AGENT_APP || 'ca-agent-gvojq4dgzbtk4' }}" \
-            "frontend:${{ vars.FRONTEND_APP || 'ca-frontend-teamskills' }}"; do
-            LABEL="${APP_PAIR%%:*}"
-            APP="${APP_PAIR#*:}"
-            DEPLOYED_IMAGE="$(az containerapp show -n "$APP" -g "$RG" \
-              --query 'properties.template.containers[0].image' -o tsv 2>/dev/null || echo 'unknown')"
-            echo "$LABEL: $DEPLOYED_IMAGE"
-            if echo "$DEPLOYED_IMAGE" | grep -q ":${EXPECTED_SHA}$"; then
-              echo "  ✅ matches expected SHA"
-            else
-              echo "  ⚠️ expected SHA $EXPECTED_SHA but got: $DEPLOYED_IMAGE"
-              ALL_OK=false
-            fi
-          done
-
-          if [ "$ALL_OK" != "true" ]; then
-            echo "❌ One or more containers did not deploy the expected image!"
-            exit 1
-          fi
-          echo "✅ All containers running expected image SHA"
-
       - name: Wait for new revisions to provision
         run: |
           RG="${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }}"
@@ -286,6 +257,36 @@ jobs:
           if [ "$AGENT_READY" != "true" ]; then
             echo "⚠️ Agent failed to become ready (non-blocking)"
           fi
+
+      - name: Verify deployed image SHAs
+        run: |
+          RG="${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }}"
+          EXPECTED_SHA="${{ github.sha }}"
+          ALL_OK=true
+
+          for APP_PAIR in \
+            "backend:${{ vars.BACKEND_APP || 'ca-backend-gvojq4dgzbtk4' }}" \
+            "agent:${{ vars.AGENT_APP || 'ca-agent-gvojq4dgzbtk4' }}" \
+            "frontend:${{ vars.FRONTEND_APP || 'ca-frontend-teamskills' }}"; do
+            LABEL="${APP_PAIR%%:*}"
+            APP="${APP_PAIR#*:}"
+            ACTIVE_IMAGE="$(az containerapp revision list -n "$APP" -g "$RG" \
+              --query "[?properties.active].properties.template.containers[0].image | [0]" \
+              -o tsv 2>/dev/null || echo 'unknown')"
+            echo "$LABEL active revision: $ACTIVE_IMAGE"
+            if echo "$ACTIVE_IMAGE" | grep -q ":${EXPECTED_SHA}$"; then
+              echo "  ✅ matches expected SHA"
+            else
+              echo "  ⚠️ expected SHA $EXPECTED_SHA but got: $ACTIVE_IMAGE"
+              ALL_OK=false
+            fi
+          done
+
+          if [ "$ALL_OK" != "true" ]; then
+            echo "❌ One or more active revisions do not match expected image!"
+            exit 1
+          fi
+          echo "✅ All active revisions running expected image SHA"
 
       - name: Initialize database (seed schema + skills)
         run: |


### PR DESCRIPTION
## Summary

Fix the CI/CD deploy pipeline that has been broken for the last 2 master pushes. Root cause: `--set-secrets` is not a valid flag for `az containerapp update`. Also incorporates hardening improvements identified by multi-model review (GPT-5.3-Codex, GPT-5.4, Claude Opus 4.6).

## Root Cause

The `Deploy backend` step used `--set-secrets init-secret=$INIT_SECRET` as an argument to `az containerapp update`. This flag does not exist on the `update` command (only on `create`). The bug was latent -- it only triggered when the `INIT_SECRET` GitHub secret was configured (previously empty, so the `if [ -n "$INIT_SECRET" ]` block was skipped).

Production has been running commit `1eef7cc` (wake removal). None of the migration or skill categorization code from PRs #81/#82 has ever deployed.

## Changes

### Fix: Secret management (the actual blocker)
- Split into `az containerapp secret set` (separate command per Azure CLI docs) then `az containerapp update --set-env-vars`
- Double-quote `"$INIT_SECRET"` for shell metacharacter safety
- Variables extracted for readability (`APP`, `RG`, `IMAGE`, `ENV_VARS`)

### Fix: Provisioning wait endpoint
- Changed from `/health` (just `SELECT 1`) to `/health/ready` (validates `skill_categories.parent_id` exists)
- Ensures migrations have completed before proceeding to DB init step
- Updated grep pattern to match `/health/ready` response format

### New: Verify deployed image SHAs
- After all three deploys, queries each container app's running image
- Confirms the deployed image tag matches `github.sha`
- Fails the pipeline if any container didn't receive the expected image

### New: actionlint CI job
- Lints workflow YAML on every push/PR using `reviewdog/action-actionlint`
- Deploy job now gates on both `test` and `actionlint`
- Would have caught the invalid `--set-secrets` flag before it shipped

## Testing

- Backend lint: passing
- No application code changes -- CI/CD workflow only
- Will verify after merge: backend logs show migration output, `/api/matrix` returns 0 uncategorized skills

## After Merge

Once deployed, the backend will boot with `migrate.js` for the first time. The idempotent migration will:
1. Ensure soft skills category exists
2. Merge duplicate skills (trailing digit variants)
3. Merge exact-name duplicates
4. Assign categories to all uncategorized skills
5. Add unique index on `skills.name`

All 111 currently uncategorized skills should be resolved.
