### PR TITLE
fix(agent): pin framework packages and restore Azure chat import

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -4,7 +4,12 @@ from typing import Optional, AsyncIterator, Any
 
 from azure.identity import DefaultAzureCredential
 from agent_framework import RawAgent
-from agent_framework.azure import AzureOpenAIChatClient
+try:
+    from agent_framework.azure import AzureOpenAIChatClient
+except ImportError:
+    # Some preview releases stopped re-exporting this symbol from
+    # agent_framework.azure even though the client still exists in core.
+    from agent_framework.azure._chat_client import AzureOpenAIChatClient
 
 from config import config
 from tools import (

--- a/agent/requirements.txt
+++ b/agent/requirements.txt
@@ -1,6 +1,8 @@
 # Agent Service Dependencies
-# Microsoft Agent Framework (preview - requires --pre flag)
-agent-framework-azure-ai
+# Microsoft Agent Framework (preview packages can break between builds; pin a known-good set)
+agent-framework-core==1.0.0rc6
+agent-framework-openai==1.0.0rc6
+agent-framework-azure-ai==1.0.0rc6
 
 # Web framework
 fastapi>=0.115.0


### PR DESCRIPTION
## Summary

Fix the production CI/CD failure after the skills rollout. The backend/frontend deploy actually succeeded and the uncategorized-skills fix is already live in production (`55` categories, `0` uncategorized skills). The failing step was the **agent** container, which crashed on startup because the preview Microsoft Agent Framework package API drifted.

## Root Cause

Azure Container Apps logs for the failed agent revision showed:

```text
cannot import name 'AzureOpenAIChatClient' from 'agent_framework.azure'
```

Two issues combined here:

1. `agent/agent.py` assumed `AzureOpenAIChatClient` is always re-exported from `agent_framework.azure`
2. `agent/requirements.txt` used an unpinned preview package (`agent-framework-azure-ai`), so builds could pick up breaking API changes over time

## Changes

| File | Change |
|------|--------|
| `agent/agent.py` | Add compatibility fallback import from `agent_framework.azure._chat_client` when the public re-export is missing |
| `agent/requirements.txt` | Pin Agent Framework packages to a known-good `1.0.0rc6` set (`core`, `openai`, `azure-ai`) |

## Why this fixes prod deploys

- The import fallback makes startup tolerant to preview package export drift
- The version pin removes nondeterminism from future container builds
- The failing Container App revision should stop crashing once rebuilt from this PR

## Validation

- `python -c "from agent import SkillsAgent; print('agent import ok')"` -> passes
- `cd agent && PYTHONPATH=. python -m pytest -q` -> `23 passed`
- Root repo tests still pass -> `112/112`

## Production status note

This PR is a **follow-up hotfix**. The original feature from PR #86 is already deployed and working in prod:

- `skill_categories`: **55 rows**
- `skills WHERE category_id IS NULL`: **0 rows**
