### PR TITLE
fix(ci): Wait for new image SHA before health-checking

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -221,37 +221,69 @@ jobs:
       - name: Wait for new revisions to provision
         run: |
           RG="${{ vars.RESOURCE_GROUP || 'rg-teamskills-prod' }}"
+          EXPECTED_SHA="${{ github.sha }}"
           BACKEND_APP="${{ vars.BACKEND_APP || 'ca-backend-gvojq4dgzbtk4' }}"
           AGENT_APP="${{ vars.AGENT_APP || 'ca-agent-gvojq4dgzbtk4' }}"
+          FRONTEND_APP="${{ vars.FRONTEND_APP || 'ca-frontend-teamskills' }}"
 
           BACKEND_URL="https://$(az containerapp show -n "$BACKEND_APP" -g "$RG" --query 'properties.configuration.ingress.fqdn' -o tsv)"
           AGENT_URL="https://$(az containerapp show -n "$AGENT_APP" -g "$RG" --query 'properties.configuration.ingress.fqdn' -o tsv)"
 
-          echo "Waiting for backend to be ready..."
-          BACKEND_READY=false
-          for i in $(seq 1 30); do
+          # Wait for all three container apps to activate the new image SHA
+          echo "Waiting for revisions with image SHA ${EXPECTED_SHA:0:12}..."
+          for APP_PAIR in \
+            "backend:${BACKEND_APP}" \
+            "agent:${AGENT_APP}" \
+            "frontend:${FRONTEND_APP}"; do
+            LABEL="${APP_PAIR%%:*}"
+            APP="${APP_PAIR#*:}"
+            echo "Waiting for $LABEL..."
+            READY=false
+            for i in $(seq 1 36); do
+              ACTIVE_IMAGE="$(az containerapp revision list -n "$APP" -g "$RG" \
+                --query "[?properties.active].properties.template.containers[0].image | [0]" \
+                -o tsv 2>/dev/null || echo 'unknown')"
+              if echo "$ACTIVE_IMAGE" | grep -q ":${EXPECTED_SHA}$"; then
+                echo "  ✅ $LABEL running expected image (attempt $i)"
+                READY=true
+                break
+              fi
+              echo "  Attempt $i/36: $LABEL still on old image, waiting 10s..."
+              sleep 10
+            done
+            if [ "$READY" != "true" ]; then
+              echo "  ❌ $LABEL did not activate expected image after 6 minutes"
+              exit 1
+            fi
+          done
+
+          # Now verify backend health with the new revision
+          echo "Verifying backend health..."
+          BACKEND_HEALTHY=false
+          for i in $(seq 1 12); do
             if curl -sf "${BACKEND_URL}/health/ready" | grep -q '"status":"ok"'; then
               echo "✅ Backend is ready (schema validated)!"
-              BACKEND_READY=true
+              BACKEND_HEALTHY=true
               break
             fi
-            echo "Attempt $i/30: Backend not ready yet, waiting 10s..."
+            echo "Attempt $i/12: Backend not healthy yet, waiting 10s..."
             sleep 10
           done
-          if [ "$BACKEND_READY" != "true" ]; then
-            echo "❌ Backend failed to become ready after 30 attempts (5 minutes)"
+          if [ "$BACKEND_HEALTHY" != "true" ]; then
+            echo "❌ Backend failed health check after new revision activated"
             exit 1
           fi
 
-          echo "Waiting for agent to be ready..."
+          # Agent health is non-blocking
+          echo "Checking agent health..."
           AGENT_READY=false
-          for i in $(seq 1 15); do
+          for i in $(seq 1 6); do
             if curl -sf "${AGENT_URL}/health" | grep -q '"healthy"'; then
               echo "✅ Agent is ready!"
               AGENT_READY=true
               break
             fi
-            echo "Attempt $i/15: Agent not ready yet, waiting 10s..."
+            echo "Attempt $i/6: Agent not ready yet, waiting 10s..."
             sleep 10
           done
           if [ "$AGENT_READY" != "true" ]; then


### PR DESCRIPTION
## Summary

Fix CI/CD deploy failure caused by a race condition in the provisioning wait step.

## Root Cause

The "Wait for new revisions to provision" step health-checked immediately after `az containerapp update`, but the OLD revision responds healthy instantly. The subsequent "Verify deployed image SHAs" step then finds all three containers still running the previous image tag and fails.

## Fix

Replace the health-only wait loop with an image SHA poll loop:

1. Poll `az containerapp revision list` for each app until the active revision's image tag matches the expected `${{ github.sha }}` (up to 6 minutes per app)
2. Only THEN run health checks against the confirmed new revision
3. Keep the existing SHA verification step as a final assertion

## Testing

- Workflow syntax validated with actionlint
- The fix addresses the exact failure seen in run [#23926556395](https://github.com/ericchansen/teamskills/actions/runs/23926556395)
