### PR TITLE
fix: convert GitHub Actions to OIDC auth, remove long-lived secrets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -86,6 +86,9 @@ jobs:
     needs: test
     if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main'
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     
     # Deploy using direct Azure CLI instead of azd.
     # Reason: Production infrastructure is brownfield (created incrementally, not by azd).
@@ -97,7 +100,9 @@ jobs:
       - name: Log in to Azure CLI
         uses: azure/login@v2
         with:
-          creds: '{"clientId":"${{ vars.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TENANT_ID }}"}'
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Build and push backend image
         run: |

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -6,6 +6,7 @@ on:
     branches: [master, main]
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
 
@@ -28,7 +29,9 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          creds: '{"clientId":"${{ vars.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TENANT_ID }}"}'
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Delete staging app registration
         run: |

--- a/.github/workflows/pr-staging.yml
+++ b/.github/workflows/pr-staging.yml
@@ -10,6 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  id-token: write
   contents: read
   pull-requests: write
 
@@ -44,7 +45,9 @@ jobs:
       - name: Log in to Azure
         uses: azure/login@v2
         with:
-          creds: '{"clientId":"${{ vars.AZURE_CLIENT_ID }}","clientSecret":"${{ secrets.AZURE_CLIENT_SECRET }}","subscriptionId":"${{ vars.AZURE_SUBSCRIPTION_ID }}","tenantId":"${{ vars.AZURE_TENANT_ID }}"}'
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Log in to ACR
         run: az acr login --name ${{ env.ACR_NAME }}


### PR DESCRIPTION
## S360 Remediation: Rotate SPN Credentials

**Control:** `Azure_Subscription_Identity_Rotate_SPN_Credentials`
**Due:** 2026-03-22 (overdue)

### Problem
The `github-teamskills` app registration had a `staging-github-environment` client secret with a **730-day lifetime** (exceeds 380-day max) and Contributor role on the subscription — triggering the S360 action item.

### Changes
- **Converted all 3 workflows to OIDC** (`ci-cd.yml`, `pr-staging.yml`, `pr-cleanup.yml`) — uses `client-id`/`tenant-id`/`subscription-id` instead of `AZURE_CLIENT_SECRET`
- Added `id-token: write` permission for OIDC token exchange
- Federated credentials added to the `github-teamskills` app for `staging` and `production` environments

### Also done (outside this PR)
- Deleted **all password credentials** from `github-teamskills` app (zero secrets remain)
- Rotated `Team Skills Tracker` Easy Auth secret from 730 → **180 days** and updated the Container App

### Post-merge
- [x] Delete `AZURE_CLIENT_SECRET` from GitHub repo staging + production environment secrets (no longer needed)
- [x] Allow 72 hours for S360 rescan to clear the action item
