### PR TITLE
feat(gap-analysis): Add configurable gap views

### DIFF
--- a/frontend/src/components/GapAnalysis.vue
+++ b/frontend/src/components/GapAnalysis.vue
@@ -191,12 +191,18 @@ function countPeopleAtOrAbove(skill, targetLevel) {
 }
 
 function buildLevelBreakdown(skill) {
-  return Object.fromEntries(
-    levelOptions.map((level) => [
-      `L${level}`,
-      people.value.filter((person) => getSkillLevel(person, skill) === level).length,
-    ])
+  const breakdown = Object.fromEntries(
+    levelOptions.map((level) => [`L${level}`, 0])
   );
+
+  for (const person of people.value) {
+    const levelKey = `L${getSkillLevel(person, skill)}`;
+    if (Object.prototype.hasOwnProperty.call(breakdown, levelKey)) {
+      breakdown[levelKey] += 1;
+    }
+  }
+
+  return breakdown;
 }
 
 function isStackedLevelVisible(level) {

--- a/frontend/src/components/GapAnalysis.vue
+++ b/frontend/src/components/GapAnalysis.vue
@@ -4,9 +4,18 @@
       <div class="control-group">
         <label for="mode-select" class="control-label">Mode:</label>
         <select id="mode-select" v-model="mode" class="mode-select">
-          <option value="expert">Expert Count (L400)</option>
-          <option value="average">Average Level</option>
-          <option value="coverage">Coverage (≥L200)</option>
+          <option v-for="option in modeOptions" :key="option.value" :value="option.value">
+            {{ option.label }}
+          </option>
+        </select>
+      </div>
+
+      <div v-if="showLevelSelector" class="control-group">
+        <label for="level-select" class="control-label">{{ levelControlLabel }}</label>
+        <select id="level-select" v-model.number="activeTargetLevel" class="mode-select">
+          <option v-for="level in levelOptions" :key="level" :value="level">
+            L{{ level }} · {{ levels[level] }}
+          </option>
         </select>
       </div>
 
@@ -20,7 +29,7 @@
         </select>
       </div>
 
-      <div class="control-group threshold-group">
+      <div v-if="showThresholdControls" class="control-group threshold-group">
         <label class="control-label">Thresholds:</label>
         <span class="threshold-label good">Good ≥</span>
         <input
@@ -37,6 +46,36 @@
           :step="modeStep"
         />
       </div>
+    </div>
+
+    <p class="mode-description">{{ modeDescription }}</p>
+
+    <div
+      v-if="showStackedLevelToggles"
+      class="level-toggles"
+      role="group"
+      aria-label="Visible proficiency levels"
+    >
+      <label
+        v-for="level in levelOptions"
+        :key="level"
+        class="level-toggle"
+        :class="{
+          active: isStackedLevelVisible(level),
+          disabled: isStackedLevelLocked(level),
+        }"
+        :title="levels[level]"
+      >
+        <input
+          type="checkbox"
+          :checked="isStackedLevelVisible(level)"
+          :disabled="isStackedLevelLocked(level)"
+          :aria-label="`L${level}`"
+          @change="toggleStackedLevel(level)"
+        />
+        <span class="level-toggle-swatch" :style="{ backgroundColor: levelColors[level] }"></span>
+        <span class="level-toggle-text">L{{ level }}</span>
+      </label>
     </div>
 
     <v-chart
@@ -60,27 +99,85 @@ import { useSkillsData } from '../composables/useSkillsData';
 import { escapeHtml, baseChartOption, chartContainerStyle } from '../composables/useChartDefaults';
 import { isE2ETestMode } from '../utils/testMode';
 
-const { people, skillCategories, categoryNames, getSkillLevel } = useSkillsData();
+const { people, skillCategories, categoryNames, getSkillLevel, levels } = useSkillsData();
 const showTestSummary = isE2ETestMode();
-
-const modeDefaults = {
-  expert:   { good: 2,   warn: 1,   step: 1  },
-  coverage: { good: 50,  warn: 25,  step: 5  },
-  average:  { good: 250, warn: 175, step: 25 },
+const levelOptions = Object.keys(levels).map(Number).sort((a, b) => a - b);
+const scalarStatusColors = {
+  good: '#61bd84',
+  warn: '#c29b5c',
+  below: '#c27575',
+};
+const levelColors = {
+  100: '#2a2e3e',
+  200: '#1e3a5f',
+  300: '#2563a8',
+  400: '#4f8ff7',
 };
 
-const mode = ref('expert');
+const modeDefaults = {
+  expert: { good: 2, warn: 1, step: 1 },
+  coverage: { good: 50, warn: 25, step: 5 },
+  average: { good: 250, warn: 175, step: 25 },
+};
+
+const mode = ref('stacked');
+const expertLevel = ref(300);
+const coverageLevel = ref(200);
+const visibleStackedLevels = ref([300, 400]);
 const selectedCategory = ref('__all__');
 const goodThreshold = ref(modeDefaults.expert.good);
 const warnThreshold = ref(modeDefaults.expert.warn);
 
 watch(mode, (m) => {
   const d = modeDefaults[m];
+  if (!d) return;
   goodThreshold.value = d.good;
   warnThreshold.value = d.warn;
 });
 
-const modeStep = computed(() => modeDefaults[mode.value].step);
+const modeOptions = computed(() => [
+  { value: 'average', label: 'Average Level' },
+  { value: 'coverage', label: 'Coverage' },
+  { value: 'expert', label: 'Expert Count' },
+  { value: 'stacked', label: 'Proficiency Breakdown' },
+]);
+
+const showLevelSelector = computed(() => mode.value === 'expert' || mode.value === 'coverage');
+const showThresholdControls = computed(() => mode.value !== 'stacked');
+const showStackedLevelToggles = computed(() => mode.value === 'stacked');
+
+const activeTargetLevel = computed({
+  get() {
+    return mode.value === 'coverage' ? coverageLevel.value : expertLevel.value;
+  },
+  set(value) {
+    const numericLevel = Number(value);
+    if (mode.value === 'coverage') {
+      coverageLevel.value = numericLevel;
+      return;
+    }
+    expertLevel.value = numericLevel;
+  },
+});
+
+const levelControlLabel = computed(() => (
+  mode.value === 'coverage' ? 'Coverage level:' : 'Expert level:'
+));
+
+const modeDescription = computed(() => {
+  if (mode.value === 'average') {
+    return 'Average proficiency level across the team for each skill.';
+  }
+  if (mode.value === 'coverage') {
+    return `Percentage of the team at or above L${coverageLevel.value} for each skill.`;
+  }
+  if (mode.value === 'stacked') {
+    return 'Stacked counts by proficiency level. Toggle the levels you want included in the chart.';
+  }
+  return `Count of people at or above L${expertLevel.value} for each skill.`;
+});
+
+const modeStep = computed(() => modeDefaults[mode.value]?.step || 1);
 
 const filteredSkills = computed(() => {
   if (selectedCategory.value === '__all__') {
@@ -89,8 +186,56 @@ const filteredSkills = computed(() => {
   return skillCategories.value[selectedCategory.value] || [];
 });
 
+function countPeopleAtOrAbove(skill, targetLevel) {
+  return people.value.filter((person) => getSkillLevel(person, skill) >= targetLevel).length;
+}
+
+function buildLevelBreakdown(skill) {
+  return Object.fromEntries(
+    levelOptions.map((level) => [
+      `L${level}`,
+      people.value.filter((person) => getSkillLevel(person, skill) === level).length,
+    ])
+  );
+}
+
+function isStackedLevelVisible(level) {
+  return visibleStackedLevels.value.includes(level);
+}
+
+function isStackedLevelLocked(level) {
+  return visibleStackedLevels.value.length === 1 && isStackedLevelVisible(level);
+}
+
+function toggleStackedLevel(level) {
+  if (isStackedLevelVisible(level)) {
+    if (isStackedLevelLocked(level)) return;
+    visibleStackedLevels.value = visibleStackedLevels.value.filter((value) => value !== level);
+    return;
+  }
+  visibleStackedLevels.value = [...visibleStackedLevels.value, level].sort((a, b) => a - b);
+}
+
 const chartMetrics = computed(() => {
   const skills = filteredSkills.value;
+  if (mode.value === 'stacked') {
+    const breakdowns = Object.fromEntries(
+      skills.map((skillName) => [skillName, buildLevelBreakdown(skillName)])
+    );
+    const series = visibleStackedLevels.value.map((level) => ({
+      key: `L${level}`,
+      label: `L${level}`,
+      color: levelColors[level],
+      values: skills.map((skillName) => breakdowns[skillName][`L${level}`] || 0),
+    }));
+
+    return {
+      skills,
+      breakdowns,
+      series,
+    };
+  }
+
   const values = skills.map((skillName) => calcMetric(skillName));
   const colors = values.map((value) => barColor(value));
 
@@ -102,25 +247,93 @@ const chartMetrics = computed(() => {
 });
 
 function calcMetric(skill) {
+  if (people.value.length === 0) {
+    return 0;
+  }
   if (mode.value === 'average') {
     const total = people.value.reduce((sum, p) => sum + getSkillLevel(p, skill), 0);
     return Math.round(total / people.value.length);
   }
   if (mode.value === 'expert') {
-    return people.value.filter((p) => getSkillLevel(p, skill) >= 400).length;
+    return countPeopleAtOrAbove(skill, expertLevel.value);
   }
-  // coverage: percentage with ≥ L200
-  const count = people.value.filter((p) => getSkillLevel(p, skill) >= 200).length;
+  const count = countPeopleAtOrAbove(skill, coverageLevel.value);
   return Math.round((count / people.value.length) * 100);
 }
 
 function barColor(val) {
-  if (val >= goodThreshold.value) return '#3ddc84';
-  if (val >= warnThreshold.value) return '#f7c948';
-  return '#f74f4f';
+  if (val >= goodThreshold.value) return scalarStatusColors.good;
+  if (val >= warnThreshold.value) return scalarStatusColors.warn;
+  return scalarStatusColors.below;
 }
 
 const chartOption = computed(() => {
+  if (mode.value === 'stacked') {
+    const { skills, series } = chartMetrics.value;
+    return {
+      ...baseChartOption(),
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'shadow' },
+        formatter(params) {
+          const total = params.reduce((sum, entry) => sum + Number(entry.value || 0), 0);
+          const detailLines = params
+            .filter((entry) => Number(entry.value || 0) > 0)
+            .map((entry) => `${escapeHtml(entry.seriesName)}: ${entry.value}`);
+
+          if (detailLines.length === 0) {
+            detailLines.push('No matching people');
+          }
+
+          detailLines.push(`<b>Total:</b> ${total} people`);
+          return `<b>${escapeHtml(params[0]?.name || '')}</b><br/>${detailLines.join('<br/>')}`;
+        },
+      },
+      grid: {
+        top: 30,
+        bottom: 30,
+        left: 220,
+        right: 40,
+      },
+      xAxis: {
+        type: 'value',
+        axisLabel: { color: '#9ca0b0', fontSize: 11 },
+        splitLine: { lineStyle: { color: '#1e2130' } },
+        axisLine: { lineStyle: { color: '#2a2e3e' } },
+      },
+      yAxis: {
+        type: 'category',
+        data: [...skills].reverse(),
+        axisLabel: {
+          color: '#e4e6ed',
+          fontSize: 11,
+          width: 190,
+          overflow: 'truncate',
+        },
+        axisLine: { lineStyle: { color: '#2a2e3e' } },
+        axisTick: { show: false },
+      },
+      series: series.map((seriesConfig) => ({
+        name: seriesConfig.label,
+        type: 'bar',
+        stack: 'proficiency',
+        emphasis: { focus: 'series' },
+        data: [...seriesConfig.values].reverse().map((value) => ({
+          value,
+          itemStyle: { color: seriesConfig.color },
+        })),
+        barMaxWidth: 18,
+        label: {
+          show: true,
+          position: 'insideRight',
+          color: '#f8fafc',
+          fontSize: 10,
+          formatter: (entry) => (entry.value ? `${entry.value}` : ''),
+        },
+      })),
+    };
+  }
+
   const { skills, values, colors } = chartMetrics.value;
 
   const suffix =
@@ -129,6 +342,15 @@ const chartOption = computed(() => {
       : mode.value === 'expert'
         ? ' people'
         : '%';
+  const tooltipValueLabel = (value) => {
+    if (mode.value === 'average') {
+      return `${value}`;
+    }
+    if (mode.value === 'expert') {
+      return `${value} people ≥L${expertLevel.value}`;
+    }
+    return `${value}% at/above L${coverageLevel.value}`;
+  };
 
   return {
     ...baseChartOption(),
@@ -137,7 +359,7 @@ const chartOption = computed(() => {
       axisPointer: { type: 'shadow' },
       formatter(params) {
         const p = params[0];
-        return `<b>${escapeHtml(p.name)}</b><br/>${p.value}${suffix}`;
+        return `<b>${escapeHtml(p.name)}</b><br/>${tooltipValueLabel(p.value)}`;
       },
     },
     grid: {
@@ -188,13 +410,26 @@ const chartOption = computed(() => {
   };
 });
 
-const metricSummary = computed(() =>
-  JSON.stringify(
+const metricSummary = computed(() => {
+  if (mode.value === 'stacked') {
+    return JSON.stringify(
+      Object.fromEntries(
+        chartMetrics.value.skills.map((skillName, index) => [
+          skillName,
+          Object.fromEntries(
+            chartMetrics.value.series.map((series) => [series.key, series.values[index]])
+          ),
+        ])
+      )
+    );
+  }
+
+  return JSON.stringify(
     Object.fromEntries(
       chartMetrics.value.skills.map((skillName, index) => [skillName, chartMetrics.value.values[index]])
     )
-  )
-);
+  );
+});
 </script>
 
 <style scoped>
@@ -210,6 +445,12 @@ const metricSummary = computed(() =>
   flex-wrap: wrap;
   gap: 20px;
   align-items: center;
+}
+
+.mode-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-secondary);
 }
 
 .control-group {
@@ -235,17 +476,63 @@ const metricSummary = computed(() =>
   margin-left: auto;
 }
 
+.level-toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.level-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--border, #2a2a4a);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.02);
+  color: var(--text-secondary, #a0a0b0);
+  cursor: pointer;
+  transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+}
+
+.level-toggle.active {
+  border-color: var(--text-primary, #e4e6ed);
+  color: var(--text-primary, #e4e6ed);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.level-toggle.disabled {
+  opacity: 0.7;
+}
+
+.level-toggle input {
+  margin: 0;
+  accent-color: var(--accent, #4f8ff7);
+}
+
+.level-toggle-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.level-toggle-text {
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
 .threshold-label {
   font-size: 0.78rem;
   font-weight: 600;
 }
 
 .threshold-label.good {
-  color: var(--green);
+  color: #84cfa1;
 }
 
 .threshold-label.warn {
-  color: var(--yellow);
+  color: #d6b175;
 }
 
 .threshold-input {

--- a/tests/e2e/userProfile.spec.js
+++ b/tests/e2e/userProfile.spec.js
@@ -14,6 +14,21 @@ async function openProfile(page) {
   await expect(page.locator('.profile-page')).toBeVisible();
 }
 
+function updateVisibleGapBreakdown(metric, fromLevel, toLevel) {
+  const nextMetric = { ...metric };
+  const trackedLevels = [300, 400];
+
+  if (trackedLevels.includes(fromLevel)) {
+    nextMetric[`L${fromLevel}`] = Math.max((nextMetric[`L${fromLevel}`] || 0) - 1, 0);
+  }
+
+  if (trackedLevels.includes(toLevel)) {
+    nextMetric[`L${toLevel}`] = (nextMetric[`L${toLevel}`] || 0) + 1;
+  }
+
+  return nextMetric;
+}
+
 test.describe('User Profile', () => {
   test.beforeEach(async ({ page }) => {
     await mockDashboardApi(page);
@@ -112,7 +127,9 @@ test.describe('Profile shared state sync', () => {
     await page.getByRole('link', { name: 'Gap Analysis' }).click();
     await expect(page.locator('.gap-view')).toBeVisible();
     const updatedGapSummary = await readJsonSummary(page, 'gap-metric-summary');
-    expect(updatedGapSummary[trackedSkill]).toBe(initialGapMetric + expectedDelta);
+    expect(updatedGapSummary[trackedSkill]).toEqual(
+      updateVisibleGapBreakdown(initialGapMetric, initialLevel, nextLevel)
+    );
   });
 
   test('should roll back shared views when a profile skill save fails', async ({ page }) => {
@@ -158,6 +175,6 @@ test.describe('Profile shared state sync', () => {
     await page.getByRole('link', { name: 'Gap Analysis' }).click();
     await expect(page.locator('.gap-view')).toBeVisible();
     const rolledBackGapSummary = await readJsonSummary(page, 'gap-metric-summary');
-    expect(rolledBackGapSummary[trackedSkill]).toBe(initialGapMetric);
+    expect(rolledBackGapSummary[trackedSkill]).toEqual(initialGapMetric);
   });
 });

--- a/tests/e2e/workflows.spec.js
+++ b/tests/e2e/workflows.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loadDashboard, mockDashboardApi } from './helpers/mockDashboardApi.js';
+import { loadDashboard, mockDashboardApi, readJsonSummary } from './helpers/mockDashboardApi.js';
 
 test.describe('Dashboard workflows', () => {
   test.beforeEach(async ({ page }) => {
@@ -31,23 +31,91 @@ test.describe('Dashboard workflows', () => {
     await expect(page.locator('.threshold-badge')).toContainText('300');
   });
 
-  test('should show the gap analysis page with configurable thresholds', async ({ page }) => {
+  test('should show the gap analysis page with configurable level controls', async ({ page }) => {
     await page.getByRole('link', { name: 'Gap Analysis' }).click();
 
     await expect(page).toHaveURL(/\/gap-analysis$/);
     await expect(page.locator('.gap-view')).toBeVisible();
-    await expect(page.locator('#mode-select')).toHaveValue('expert');
-    await expect(page.locator('.threshold-input').first()).toHaveValue('2');
-    await expect(page.locator('.threshold-input').nth(1)).toHaveValue('1');
+    await expect(page.locator('#mode-select option')).toHaveText([
+      'Average Level',
+      'Coverage',
+      'Expert Count',
+      'Proficiency Breakdown',
+    ]);
+    await expect(page.locator('#mode-select')).toHaveValue('stacked');
+    await expect(page.locator('#level-select')).toHaveCount(0);
+    await expect(page.locator('.threshold-input')).toHaveCount(0);
+    await expect(page.getByRole('checkbox', { name: 'L100' })).not.toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'L200' })).not.toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'L300' })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'L400' })).toBeChecked();
   });
 
-  test('should update gap-analysis thresholds when switching modes', async ({ page }) => {
+  test('should update gap-analysis controls when switching modes', async ({ page }) => {
     await page.getByRole('link', { name: 'Gap Analysis' }).click();
 
-    await page.locator('#mode-select').selectOption('average');
+    await page.locator('#mode-select').selectOption('coverage');
+    await expect(page.locator('#level-select')).toHaveValue('200');
+    await expect(page.locator('.threshold-input').first()).toHaveValue('50');
+    await expect(page.locator('.threshold-input').nth(1)).toHaveValue('25');
 
+    await page.locator('#mode-select').selectOption('average');
+    await expect(page.locator('#level-select')).toHaveCount(0);
     await expect(page.locator('.threshold-input').first()).toHaveValue('250');
     await expect(page.locator('.threshold-input').nth(1)).toHaveValue('175');
+
+    await page.locator('#mode-select').selectOption('stacked');
+    await expect(page.locator('#level-select')).toHaveCount(0);
+    await expect(page.locator('.threshold-input')).toHaveCount(0);
+    await expect(page.getByRole('checkbox', { name: 'L100' })).not.toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'L200' })).not.toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'L300' })).toBeChecked();
+    await expect(page.getByRole('checkbox', { name: 'L400' })).toBeChecked();
+  });
+
+  test('should recalculate expert and coverage metrics when the target level changes', async ({ page }) => {
+    const trackedSkill = 'Azure AI Services (OpenAI)';
+
+    await page.getByRole('link', { name: 'Gap Analysis' }).click();
+    await page.locator('#mode-select').selectOption('expert');
+
+    let summary = await readJsonSummary(page, 'gap-metric-summary');
+    expect(summary[trackedSkill]).toBe(1);
+
+    await page.locator('#level-select').selectOption('400');
+    summary = await readJsonSummary(page, 'gap-metric-summary');
+    expect(summary[trackedSkill]).toBe(0);
+
+    await page.locator('#mode-select').selectOption('coverage');
+    summary = await readJsonSummary(page, 'gap-metric-summary');
+    expect(summary[trackedSkill]).toBe(100);
+
+    await page.locator('#level-select').selectOption('300');
+    summary = await readJsonSummary(page, 'gap-metric-summary');
+    expect(summary[trackedSkill]).toBe(33);
+  });
+
+  test('should show stacked proficiency counts for visible levels and allow toggling levels', async ({ page }) => {
+    const trackedSkill = 'Microsoft Foundry';
+
+    await page.getByRole('link', { name: 'Gap Analysis' }).click();
+    await page.locator('#mode-select').selectOption('stacked');
+
+    let summary = await readJsonSummary(page, 'gap-metric-summary');
+    expect(summary[trackedSkill]).toEqual({
+      L300: 1,
+      L400: 1,
+    });
+
+    await page.getByRole('checkbox', { name: 'L100' }).evaluate((element) => {
+      element.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    summary = await readJsonSummary(page, 'gap-metric-summary');
+    expect(summary[trackedSkill]).toEqual({
+      L100: 1,
+      L300: 1,
+      L400: 1,
+    });
   });
 
   test('should keep the skill catalog editor out of the primary nav and open it from profile', async ({ page }) => {


### PR DESCRIPTION
## Summary

Add configurable controls and a stacked breakdown to Gap Analysis so teams can inspect coverage at different proficiency thresholds.

## Changes

- add configurable Expert Count and Coverage level selectors
- keep Expert Count defaulted to L300 and Coverage defaulted to L200 based on the agreed product direction for this PR
- add a stacked Proficiency Breakdown mode and make it the default view
- polish mode labels, semantic colors, and stacked toggle styling to match the dashboard
- optimize stacked breakdown counting to use a single pass over the team data
- update workflow and shared-state Playwright coverage for the new gap-analysis behavior

## Testing

- npm run lint
- npm test
- BASE_URL=http://127.0.0.1:3000 npx playwright test --project="msedge" --workers=1 --reporter=line

Closes #91
