### PR TITLE
feat(gap-analysis): tooltip names, dropdown arrows, CSS consistency

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -107,11 +107,11 @@ watch(isAuthenticated, (signedIn) => {
 
 .error-icon {
   font-size: 2rem;
-  color: #ef4444;
+  color: var(--danger);
 }
 
 .error-screen p {
-  color: #ef4444;
+  color: var(--danger);
   font-size: 1rem;
   margin: 0;
 }
@@ -119,10 +119,10 @@ watch(isAuthenticated, (signedIn) => {
 .retry-btn {
   margin-top: 0.5rem;
   padding: 0.5rem 1.25rem;
-  background: var(--accent);
+  background-color: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 6px;
+  border-radius: var(--radius);
   cursor: pointer;
   font-size: 0.9rem;
 }
@@ -152,17 +152,17 @@ watch(isAuthenticated, (signedIn) => {
 }
 
 .auth-error-msg {
-  color: #ef4444 !important;
+  color: var(--danger) !important;
   font-size: 0.9rem;
 }
 
 .login-btn {
   margin-top: 0.5rem;
   padding: 0.75rem 1.5rem;
-  background: var(--accent, #3b82f6);
+  background-color: var(--accent);
   color: #fff;
   border: none;
-  border-radius: 8px;
+  border-radius: var(--radius);
   cursor: pointer;
   font-size: 1rem;
   display: flex;

--- a/frontend/src/components/AppHeader.vue
+++ b/frontend/src/components/AppHeader.vue
@@ -64,8 +64,8 @@ const navRoutes = computed(() =>
   align-items: center;
   gap: 1.5rem;
   padding: 0.5rem 1.5rem;
-  background: var(--bg-secondary, #1a1a2e);
-  border-bottom: 1px solid var(--border, #2a2a4a);
+  background-color: var(--bg-secondary);
+  border-bottom: 1px solid var(--border);
   min-height: 48px;
 }
 
@@ -80,19 +80,19 @@ const navRoutes = computed(() =>
   font-size: 1.1rem;
   font-weight: 600;
   margin: 0;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .live-badge {
   font-size: 0.7rem;
-  color: #4ade80;
+  color: var(--success);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
 
 .demo-badge {
   font-size: 0.7rem;
-  color: #fbbf24;
+  color: var(--warning);
   letter-spacing: 0.05em;
   text-transform: uppercase;
 }
@@ -106,8 +106,8 @@ const navRoutes = computed(() =>
 
 .nav-link {
   padding: 0.4rem 0.8rem;
-  border-radius: 6px;
-  color: var(--text-secondary, #a0a0b0);
+  border-radius: var(--radius);
+  color: var(--text-secondary);
   text-decoration: none;
   font-size: 0.85rem;
   font-weight: 500;
@@ -115,13 +115,13 @@ const navRoutes = computed(() =>
 }
 
 .nav-link:hover {
-  color: var(--text-primary, #e0e0e0);
-  background: rgba(255, 255, 255, 0.06);
+  color: var(--text-primary);
+  background-color: rgba(255, 255, 255, 0.06);
 }
 
 .nav-link.active {
-  color: var(--accent, #818cf8);
-  background: rgba(129, 140, 248, 0.12);
+  color: var(--accent);
+  background-color: rgba(129, 140, 248, 0.12);
 }
 
 .header-user {
@@ -133,16 +133,16 @@ const navRoutes = computed(() =>
 
 .user-name {
   font-size: 0.85rem;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   text-decoration: none;
 }
 
 .user-name:hover {
-  color: var(--accent, #818cf8);
+  color: var(--accent);
 }
 
 .user-name.muted {
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   font-style: italic;
   font-size: 0.75rem;
 }
@@ -150,29 +150,29 @@ const navRoutes = computed(() =>
 .btn-login,
 .btn-logout {
   padding: 0.3rem 0.7rem;
-  border-radius: 6px;
-  border: 1px solid var(--border, #2a2a4a);
-  background: transparent;
-  color: var(--text-secondary, #a0a0b0);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background-color: transparent;
+  color: var(--text-secondary);
   font-size: 0.8rem;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .btn-login:hover {
-  background: var(--accent, #818cf8);
+  background-color: var(--accent);
   color: #fff;
-  border-color: var(--accent, #818cf8);
+  border-color: var(--accent);
 }
 
 .btn-logout:hover {
-  background: rgba(248, 113, 113, 0.15);
-  color: #f87171;
-  border-color: #f87171;
+  background-color: rgba(248, 113, 113, 0.15);
+  color: var(--danger);
+  border-color: var(--danger);
 }
 
 .loading-dot {
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   animation: pulse 1.5s infinite;
 }
 

--- a/frontend/src/components/GapAnalysis.vue
+++ b/frontend/src/components/GapAnalysis.vue
@@ -190,6 +190,26 @@ function countPeopleAtOrAbove(skill, targetLevel) {
   return people.value.filter((person) => getSkillLevel(person, skill) >= targetLevel).length;
 }
 
+function getPeopleNamesAtLevel(skill, level) {
+  return people.value
+    .filter((person) => getSkillLevel(person, skill) === level)
+    .map((person) => person.name);
+}
+
+function getPeopleNamesAtOrAbove(skill, level) {
+  return people.value
+    .filter((person) => getSkillLevel(person, skill) >= level)
+    .map((person) => person.name);
+}
+
+function formatNameList(names) {
+  if (names.length === 0) return '';
+  const sorted = [...names].sort((a, b) => a.localeCompare(b));
+  const escaped = sorted.map(escapeHtml);
+  if (escaped.length <= 8) return escaped.join(', ');
+  return `${escaped.slice(0, 8).join(', ')} +${escaped.length - 8} more`;
+}
+
 function buildLevelBreakdown(skill) {
   const breakdown = Object.fromEntries(
     levelOptions.map((level) => [`L${level}`, 0])
@@ -282,17 +302,23 @@ const chartOption = computed(() => {
         trigger: 'axis',
         axisPointer: { type: 'shadow' },
         formatter(params) {
+          const skillName = params[0]?.name || '';
           const total = params.reduce((sum, entry) => sum + Number(entry.value || 0), 0);
           const detailLines = params
             .filter((entry) => Number(entry.value || 0) > 0)
-            .map((entry) => `${escapeHtml(entry.seriesName)}: ${entry.value}`);
+            .map((entry) => {
+              const level = Number(entry.seriesName.replace('L', ''));
+              const names = getPeopleNamesAtLevel(skillName, level);
+              const nameStr = names.length > 0 ? ` — ${formatNameList(names)}` : '';
+              return `${escapeHtml(entry.seriesName)}: ${entry.value}${nameStr}`;
+            });
 
           if (detailLines.length === 0) {
             detailLines.push('No matching people');
           }
 
           detailLines.push(`<b>Total:</b> ${total} people`);
-          return `<b>${escapeHtml(params[0]?.name || '')}</b><br/>${detailLines.join('<br/>')}`;
+          return `<b>${escapeHtml(skillName)}</b><br/>${detailLines.join('<br/>')}`;
         },
       },
       grid: {
@@ -365,7 +391,15 @@ const chartOption = computed(() => {
       axisPointer: { type: 'shadow' },
       formatter(params) {
         const p = params[0];
-        return `<b>${escapeHtml(p.name)}</b><br/>${tooltipValueLabel(p.value)}`;
+        let nameList = '';
+        if (mode.value === 'expert') {
+          const names = getPeopleNamesAtOrAbove(p.name, expertLevel.value);
+          if (names.length > 0) nameList = `<br/>${formatNameList(names)}`;
+        } else if (mode.value === 'coverage') {
+          const names = getPeopleNamesAtOrAbove(p.name, coverageLevel.value);
+          if (names.length > 0) nameList = `<br/>${formatNameList(names)}`;
+        }
+        return `<b>${escapeHtml(p.name)}</b><br/>${tooltipValueLabel(p.value)}${nameList}`;
       },
     },
     grid: {

--- a/frontend/src/components/GapAnalysis.vue
+++ b/frontend/src/components/GapAnalysis.vue
@@ -528,18 +528,18 @@ const metricSummary = computed(() => {
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  border: 1px solid var(--border, #2a2a4a);
+  border: 1px solid var(--border);
   border-radius: 999px;
-  background: rgba(255, 255, 255, 0.02);
-  color: var(--text-secondary, #a0a0b0);
+  background-color: rgba(255, 255, 255, 0.02);
+  color: var(--text-secondary);
   cursor: pointer;
   transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
 }
 
 .level-toggle.active {
-  border-color: var(--text-primary, #e4e6ed);
-  color: var(--text-primary, #e4e6ed);
-  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--text-primary);
+  color: var(--text-primary);
+  background-color: rgba(255, 255, 255, 0.05);
 }
 
 .level-toggle.disabled {
@@ -548,7 +548,7 @@ const metricSummary = computed(() => {
 
 .level-toggle input {
   margin: 0;
-  accent-color: var(--accent, #4f8ff7);
+  accent-color: var(--accent);
 }
 
 .level-toggle-swatch {
@@ -568,11 +568,11 @@ const metricSummary = computed(() => {
 }
 
 .threshold-label.good {
-  color: #84cfa1;
+  color: var(--success);
 }
 
 .threshold-label.warn {
-  color: #d6b175;
+  color: var(--warning);
 }
 
 .threshold-input {

--- a/frontend/src/components/GapAnalysis.vue
+++ b/frontend/src/components/GapAnalysis.vue
@@ -508,7 +508,7 @@ const metricSummary = computed(() => {
 }
 
 .mode-select {
-  padding: 6px 12px;
+  padding: 6px 2rem 6px 12px;
   font-size: 0.85rem;
 }
 

--- a/frontend/src/components/SkillCatalog.vue
+++ b/frontend/src/components/SkillCatalog.vue
@@ -471,8 +471,8 @@ onMounted(async () => {
 
 .panel-card,
 .info-card {
-  background: var(--bg-secondary, #1a1a2e);
-  border: 1px solid var(--border, #2a2a4a);
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border);
   border-radius: 12px;
 }
 
@@ -493,7 +493,7 @@ onMounted(async () => {
   flex-direction: column;
   gap: 0.65rem;
   font-size: 0.9rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
 }
 
 .field input,
@@ -501,10 +501,10 @@ onMounted(async () => {
 .field textarea,
 .secondary-btn,
 .primary-btn {
-  border-radius: 10px;
-  border: 1px solid var(--border, #2a2a4a);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
   background-color: var(--bg-tertiary, #111829);
-  color: var(--text-primary, #f4f6fb);
+  color: var(--text-primary);
   font: inherit;
 }
 
@@ -537,7 +537,7 @@ onMounted(async () => {
 
 .field-hint {
   margin: 0.1rem 0 0;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   line-height: 1.45;
 }
 
@@ -561,7 +561,7 @@ onMounted(async () => {
 }
 
 .primary-btn {
-  background: linear-gradient(135deg, #4f74ff, #7b5bff);
+  background: linear-gradient(135deg, var(--accent), #7b5bff);
   border: none;
   color: #fff;
   font-weight: 600;
@@ -580,11 +580,11 @@ onMounted(async () => {
 }
 
 .form-message.success {
-  color: #7dd3a0;
+  color: var(--success);
 }
 
 .form-message.error {
-  color: #ff8f8f;
+  color: var(--danger);
 }
 
 @media (max-width: 640px) {

--- a/frontend/src/components/SkillCatalog.vue
+++ b/frontend/src/components/SkillCatalog.vue
@@ -503,7 +503,7 @@ onMounted(async () => {
 .primary-btn {
   border-radius: 10px;
   border: 1px solid var(--border, #2a2a4a);
-  background: var(--bg-tertiary, #111829);
+  background-color: var(--bg-tertiary, #111829);
   color: var(--text-primary, #f4f6fb);
   font: inherit;
 }
@@ -512,6 +512,10 @@ onMounted(async () => {
 .field select,
 .field textarea {
   padding: 0.85rem 1rem;
+}
+
+.field select:not([multiple]) {
+  padding-right: 2.25rem;
 }
 
 .field textarea {

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -290,9 +290,9 @@ onMounted(async () => {
 
 /* ── Skills editor ──────────────── */
 .skills-editor {
-  background: var(--bg-secondary, #1a1a2e);
+  background-color: var(--bg-secondary);
   border-radius: 12px;
-  border: 1px solid var(--border, #2a2a4a);
+  border: 1px solid var(--border);
   padding: 1rem 1.5rem;
 }
 
@@ -306,18 +306,18 @@ onMounted(async () => {
 .editor-header h3 {
   margin: 0;
   font-size: 1rem;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .save-status {
   font-size: 0.8rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
 }
 .save-status.saved {
-  color: #4ade80;
+  color: var(--success);
 }
 .save-status.error {
-  color: #f87171;
+  color: var(--danger);
 }
 .save-status.muted {
   font-style: italic;
@@ -337,7 +337,7 @@ onMounted(async () => {
   gap: 0.35rem;
   min-width: 140px;
   font-size: 0.75rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -347,10 +347,10 @@ onMounted(async () => {
 }
 
 .filter-input {
-  border-radius: 8px;
-  border: 1px solid var(--border, #2a2a4a);
-  background-color: var(--bg-primary, #12121f);
-  color: var(--text-primary, #e0e0e0);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
   padding: 0.6rem 0.75rem;
   font-size: 0.9rem;
 }
@@ -363,17 +363,17 @@ select.filter-input {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   font-size: 0.85rem;
   padding-bottom: 0.55rem;
 }
 
 .clear-filters-btn,
 .catalog-link {
-  border-radius: 8px;
-  border: 1px solid var(--border, #2a2a4a);
-  background: transparent;
-  color: var(--text-primary, #e0e0e0);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background-color: transparent;
+  color: var(--text-primary);
   padding: 0.6rem 0.85rem;
   font-size: 0.85rem;
   text-decoration: none;
@@ -396,7 +396,7 @@ select.filter-input {
   gap: 0.75rem;
   align-items: center;
   padding: 0.85rem 1rem;
-  border-radius: 10px;
+  border-radius: var(--radius-lg);
 }
 
 .profile-sync-help {
@@ -417,12 +417,12 @@ select.filter-input {
   margin: 0 0 0.25rem;
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
 }
 
 .profile-help-copy p {
   margin: 0;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   font-size: 0.85rem;
   line-height: 1.5;
 }
@@ -445,7 +445,7 @@ select.filter-input {
 .results-summary,
 .no-results-msg {
   margin: 0 0 0.85rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   font-size: 0.85rem;
 }
 
@@ -461,14 +461,14 @@ select.filter-input {
   padding: 0.5rem 0;
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--text-primary, #e0e0e0);
+  color: var(--text-primary);
   cursor: pointer;
   user-select: none;
-  border-bottom: 1px solid var(--border, #2a2a4a);
+  border-bottom: 1px solid var(--border);
 }
 
 .cat-header:hover {
-  color: var(--accent, #818cf8);
+  color: var(--accent);
 }
 
 .cat-chevron {
@@ -483,7 +483,7 @@ select.filter-input {
 
 .cat-count {
   font-size: 0.7rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   font-weight: 400;
 }
 
@@ -499,7 +499,7 @@ select.filter-input {
   margin: 0 0 0.35rem;
   font-size: 0.75rem;
   font-weight: 600;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }

--- a/frontend/src/components/UserProfile.vue
+++ b/frontend/src/components/UserProfile.vue
@@ -349,10 +349,14 @@ onMounted(async () => {
 .filter-input {
   border-radius: 8px;
   border: 1px solid var(--border, #2a2a4a);
-  background: var(--bg-primary, #12121f);
+  background-color: var(--bg-primary, #12121f);
   color: var(--text-primary, #e0e0e0);
   padding: 0.6rem 0.75rem;
   font-size: 0.9rem;
+}
+
+select.filter-input {
+  padding-right: 2.25rem;
 }
 
 .filter-toggle {

--- a/frontend/src/components/v2/SkillLevelRow.vue
+++ b/frontend/src/components/v2/SkillLevelRow.vue
@@ -42,7 +42,7 @@ defineEmits(['update:level']);
 
 .skill-name {
   font-size: 0.8rem;
-  color: var(--text-secondary, #a0a0b0);
+  color: var(--text-secondary);
   flex: 1;
   min-width: 0;
   overflow: hidden;
@@ -59,17 +59,18 @@ defineEmits(['update:level']);
 .level-btn {
   width: 38px;
   height: 26px;
-  border: 1px solid var(--border, #2a2a4a);
+  border: 1px solid var(--border);
   border-radius: 4px;
-  background: transparent;
-  color: var(--text-secondary, #a0a0b0);
+  background-color: transparent;
+  color: var(--text-secondary);
   font-size: 0.7rem;
+  padding: 0;
   cursor: pointer;
   transition: all 0.15s;
 }
 
 .level-btn:hover:not(:disabled) {
-  border-color: var(--text-secondary, #a0a0b0);
+  border-color: var(--text-secondary);
 }
 
 .level-btn:disabled {
@@ -78,22 +79,22 @@ defineEmits(['update:level']);
 }
 
 .level-btn.active.l100 {
-  background: #334155;
+  background-color: #334155;
   border-color: #475569;
   color: #94a3b8;
 }
 .level-btn.active.l200 {
-  background: #1e3a5f;
+  background-color: #1e3a5f;
   border-color: #2563eb;
   color: #60a5fa;
 }
 .level-btn.active.l300 {
-  background: #14532d;
+  background-color: #14532d;
   border-color: #16a34a;
-  color: #4ade80;
+  color: var(--success);
 }
 .level-btn.active.l400 {
-  background: #581c87;
+  background-color: #581c87;
   border-color: #9333ea;
   color: #c084fc;
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -21,7 +21,19 @@
   --yellow: #f7c948;
   --red: #f74f4f;
   --radius: 8px;
+  --radius-lg: 10px;
   --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+  /* Semantic aliases */
+  --success: var(--green);
+  --warning: var(--yellow);
+  --danger: var(--red);
+
+  /* Proficiency level tiers */
+  --level-100: #334155;
+  --level-200: #1e3a5f;
+  --level-300: #2563a8;
+  --level-400: #4f8ff7;
 }
 
 html,
@@ -43,6 +55,22 @@ body {
 button {
   font-family: var(--font);
   cursor: pointer;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background-color: transparent;
+  color: var(--text-primary);
+  padding: 6px 14px;
+  font-size: 0.85rem;
+  transition: background-color 0.15s, border-color 0.15s;
+}
+
+button:hover {
+  background-color: var(--bg-hover);
+}
+
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
 }
 
 input,
@@ -57,7 +85,7 @@ select {
   transition: border-color 0.2s;
 }
 
-select {
+select:not([multiple]) {
   appearance: none;
   padding-right: 2.25rem;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6' fill='%239ca0b0'/%3E%3C/svg%3E");
@@ -88,5 +116,5 @@ select option {
   border-radius: 4px;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: #3a3e50;
+  background: var(--bg-hover);
 }

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -48,13 +48,22 @@ button {
 input,
 select {
   font-family: var(--font);
-  background: var(--bg-secondary);
+  background-color: var(--bg-secondary);
   color: var(--text-primary);
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 6px 12px;
   outline: none;
   transition: border-color 0.2s;
+}
+
+select {
+  appearance: none;
+  padding-right: 2.25rem;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6'%3E%3Cpath d='M0 0l5 6 5-6' fill='%239ca0b0'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  cursor: pointer;
 }
 
 input:focus,


### PR DESCRIPTION
## Summary

Show people names in Gap Analysis tooltips, fix select dropdown styling, and improve CSS consistency across the app.

### Changes

**Tooltip names (GapAnalysis.vue)**
- Stacked (Proficiency Breakdown) tooltips now show names per level (e.g. `L300: 2 -- Alice, Bob`)
- Expert Count tooltips show names of people at or above the selected level
- Coverage tooltips show names of people meeting the threshold
- Names sorted alphabetically and truncated at 8 with `+N more` for larger teams

**Select dropdown arrows (global + 3 components)**
- Used `appearance: none` on `select:not([multiple])` with a custom SVG chevron positioned 12px from the right edge
- Multi-selects (`<select multiple>`) retain native browser appearance
- Switched `background:` to `background-color:` in scoped component styles to avoid clobbering the arrow's `background-image`
- Fixed in `style.css`, `UserProfile.vue`, `GapAnalysis.vue`, `SkillCatalog.vue`

**CSS consistency and accessibility (7 files)**
- Added semantic color vars (`--success`, `--warning`, `--danger`) and proficiency tier vars (`--level-100` through `--level-400`)
- Added global `:focus-visible` outline for keyboard navigation accessibility
- Added global button base styles (padding, border-radius, border, transition)
- Replaced ~30 hardcoded hex colors with CSS var references
- Added `--radius-lg: 10px` token for larger border-radius contexts

### Testing

- 113 unit tests pass
- Verified tooltips locally in Proficiency Breakdown and Expert Count modes
- Verified dropdown arrow spacing on Profile and Gap Analysis pages
- Keyboard-tabbed through pages to confirm focus rings appear
